### PR TITLE
dx: add ESLint + Prettier with CI integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,12 @@ jobs:
 
       - run: npm ci
 
+      - name: Lint
+        run: npx eslint src/
+
+      - name: Format check
+        run: npx prettier --check src/
+
       - name: Type check
         run: npx tsc --noEmit
 

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "tabWidth": 2,
+  "printWidth": 100
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,18 @@
+import eslint from '@eslint/js';
+import tseslint from 'typescript-eslint';
+import eslintConfigPrettier from 'eslint-config-prettier';
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  ...tseslint.configs.recommended,
+  eslintConfigPrettier,
+  { ignores: ['dist/', 'node_modules/', '.worktrees/'] },
+  {
+    rules: {
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
+    },
+  },
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,13 +12,18 @@
         "three": "^0.183.2"
       },
       "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "@types/pngjs": "^6.0.5",
         "@types/three": "^0.183.1",
         "@vitest/browser": "^4.1.0",
+        "eslint": "^10.0.3",
+        "eslint-config-prettier": "^10.1.8",
         "jsdom": "^29.0.0",
         "pngjs": "^7.0.0",
+        "prettier": "^3.8.1",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
+        "typescript-eslint": "^8.57.1",
         "vite": "^8.0.0",
         "vitest": "^4.1.0"
       }
@@ -707,6 +712,134 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.3",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.3.tgz",
+      "integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
+      "integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
+      "integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
+      "integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
+      "integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
     "node_modules/@exodus/bytes": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
@@ -723,6 +856,58 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -1081,10 +1266,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1137,6 +1336,236 @@
       "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.1.tgz",
+      "integrity": "sha512-Gn3aqnvNl4NGc6x3/Bqk1AOn0thyTU9bqDRhiRnUWezgvr2OnhYCWCgC8zXXRVqBsIL1pSDt7T9nJUe0oM0kDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.57.1",
+        "@typescript-eslint/type-utils": "8.57.1",
+        "@typescript-eslint/utils": "8.57.1",
+        "@typescript-eslint/visitor-keys": "8.57.1",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.57.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.1.tgz",
+      "integrity": "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.57.1",
+        "@typescript-eslint/types": "8.57.1",
+        "@typescript-eslint/typescript-estree": "8.57.1",
+        "@typescript-eslint/visitor-keys": "8.57.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.1.tgz",
+      "integrity": "sha512-vx1F37BRO1OftsYlmG9xay1TqnjNVlqALymwWVuYTdo18XuKxtBpCj1QlzNIEHlvlB27osvXFWptYiEWsVdYsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.57.1",
+        "@typescript-eslint/types": "^8.57.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.1.tgz",
+      "integrity": "sha512-hs/QcpCwlwT2L5S+3fT6gp0PabyGk4Q0Rv2doJXA0435/OpnSR3VRgvrp8Xdoc3UAYSg9cyUjTeFXZEPg/3OKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.57.1",
+        "@typescript-eslint/visitor-keys": "8.57.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.1.tgz",
+      "integrity": "sha512-0lgOZB8cl19fHO4eI46YUx2EceQqhgkPSuCGLlGi79L2jwYY1cxeYc1Nae8Aw1xjgW3PKVDLlr3YJ6Bxx8HkWg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.57.1.tgz",
+      "integrity": "sha512-+Bwwm0ScukFdyoJsh2u6pp4S9ktegF98pYUU0hkphOOqdMB+1sNQhIz8y5E9+4pOioZijrkfNO/HUJVAFFfPKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.57.1",
+        "@typescript-eslint/typescript-estree": "8.57.1",
+        "@typescript-eslint/utils": "8.57.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.1.tgz",
+      "integrity": "sha512-S29BOBPJSFUiblEl6RzPPjJt6w25A6XsBqRVDt53tA/tlL8q7ceQNZHTjPeONt/3S7KRI4quk+yP9jK2WjBiPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.1.tgz",
+      "integrity": "sha512-ybe2hS9G6pXpqGtPli9Gx9quNV0TWLOmh58ADlmZe9DguLq0tiAKVjirSbtM1szG6+QH6rVXyU6GTLQbWnMY+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.57.1",
+        "@typescript-eslint/tsconfig-utils": "8.57.1",
+        "@typescript-eslint/types": "8.57.1",
+        "@typescript-eslint/visitor-keys": "8.57.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.1.tgz",
+      "integrity": "sha512-XUNSJ/lEVFttPMMoDVA2r2bwrl8/oPx8cURtczkSEswY5T3AeLmCy+EKWQNdL4u0MmAHOjcWrqJp2cdvgjn8dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.57.1",
+        "@typescript-eslint/types": "8.57.1",
+        "@typescript-eslint/typescript-estree": "8.57.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.1.tgz",
+      "integrity": "sha512-YWnmJkXbofiz9KbnbbwuA2rpGkFPLbAIetcCNO6mJ8gdhdZ/v7WDXsoGFAJuM6ikUFKTlSQnjWnVO4ux+UzS6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.57.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
     },
     "node_modules/@vitest/browser": {
       "version": "4.1.0",
@@ -1281,6 +1710,46 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1291,6 +1760,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -1299,6 +1778,19 @@
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/chai": {
@@ -1317,6 +1809,21 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/css-tree": {
       "version": "3.2.1",
@@ -1346,10 +1853,35 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/decimal.js": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1425,6 +1957,177 @@
         "@esbuild/win32-x64": "0.27.4"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.3.tgz",
+      "integrity": "sha512-COV33RzXZkqhG9P2rZCFl9ZmJ7WL+gQSCRzE7RhkbclbQPtLAWReL7ysA0Sh4c8Im2U9ynybdR56PV0XcKvqaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.3",
+        "@eslint/config-helpers": "^0.5.2",
+        "@eslint/core": "^1.1.1",
+        "@eslint/plugin-kit": "^0.6.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.1.1",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -1433,6 +2136,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/expect-type": {
@@ -1444,6 +2157,27 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -1469,6 +2203,57 @@
       "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -1498,6 +2283,19 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -1511,12 +2309,62 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/jsdom": {
       "version": "29.0.0",
@@ -1557,6 +2405,51 @@
         "canvas": {
           "optional": true
         }
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lightningcss": {
@@ -1820,6 +2713,22 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "11.2.7",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
@@ -1854,6 +2763,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -1863,6 +2788,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -1883,6 +2815,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -1893,6 +2832,56 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/parse5": {
       "version": "8.0.0",
@@ -1905,6 +2894,26 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/pathe": {
@@ -1971,6 +2980,32 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/punycode": {
@@ -2048,6 +3083,42 @@
       },
       "engines": {
         "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/siginfo": {
@@ -2209,6 +3280,19 @@
         "node": ">=20"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -2237,6 +3321,19 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -2249,6 +3346,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.57.1.tgz",
+      "integrity": "sha512-fLvZWf+cAGw3tqMCYzGIU6yR8K+Y9NT2z23RwOjlNFF2HwSB3KhdEFI5lSBv8tNmFkkBShSjsCjzx1vahZfISA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.57.1",
+        "@typescript-eslint/parser": "8.57.1",
+        "@typescript-eslint/typescript-estree": "8.57.1",
+        "@typescript-eslint/utils": "8.57.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/undici": {
@@ -2267,6 +3388,16 @@
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
     },
     "node_modules/vite": {
       "version": "8.0.0",
@@ -2477,6 +3608,22 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -2492,6 +3639,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ws": {
@@ -2532,6 +3689,19 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,11 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "test": "vitest"
+    "test": "vitest",
+    "lint": "eslint src/",
+    "lint:fix": "eslint src/ --fix",
+    "format": "prettier --write src/",
+    "format:check": "prettier --check src/"
   },
   "repository": {
     "type": "git",
@@ -27,13 +31,18 @@
     "three": "^0.183.2"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "@types/pngjs": "^6.0.5",
     "@types/three": "^0.183.1",
     "@vitest/browser": "^4.1.0",
+    "eslint": "^10.0.3",
+    "eslint-config-prettier": "^10.1.8",
     "jsdom": "^29.0.0",
     "pngjs": "^7.0.0",
+    "prettier": "^3.8.1",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
+    "typescript-eslint": "^8.57.1",
     "vite": "^8.0.0",
     "vitest": "^4.1.0"
   }

--- a/src/effects/ScreenShake.test.ts
+++ b/src/effects/ScreenShake.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { ScreenShake, SCREEN_SHAKE_INTENSITY, SCREEN_SHAKE_DURATION } from './ScreenShake';
+import { ScreenShake, SCREEN_SHAKE_DURATION } from './ScreenShake';
 
 describe('ScreenShake', () => {
   it('initial state returns zero offsets', () => {

--- a/src/engine/Game.ts
+++ b/src/engine/Game.ts
@@ -21,11 +21,17 @@ import { ViewMode } from '../player/ViewMode';
 import { applyKnockback, KNOCKBACK_VERTICAL } from '../physics/Knockback';
 import { Entity } from '../entity/Entity';
 import { Minion } from '../entity/Minion';
-import { ATTACK_RANGE, ATTACK_DAMAGE, ATTACK_COOLDOWN } from '../entity/CombatSystem';
+import { ATTACK_RANGE, ATTACK_DAMAGE } from '../entity/CombatSystem';
 import { buildModel } from '../model/MobModel';
 import { SHEEP_MODEL, PLAYER_MODEL } from '../model/ModelDefinitions';
 import { WalkAnimator, AttackAnimator } from '../model/Animator';
-import { createDamageFlash, triggerFlash, updateFlash, applyFlashToMesh, DamageFlashState } from '../model/DamageFlash';
+import {
+  createDamageFlash,
+  triggerFlash,
+  updateFlash,
+  applyFlashToMesh,
+  DamageFlashState,
+} from '../model/DamageFlash';
 
 export class Game {
   private renderer!: Renderer;
@@ -82,7 +88,7 @@ export class Game {
       // 将来のインベントリドロップ拡張ポイント
     });
 
-    this.towerAIs = this.structures.map(s => new TowerAI(s));
+    this.towerAIs = this.structures.map((s) => new TowerAI(s));
     this.projectileManager = new ProjectileManager(this.renderer.scene);
     this.screenShake = new ScreenShake();
     // プレイヤーをProjectileTargetとして表すアダプターオブジェクト
@@ -129,10 +135,7 @@ export class Game {
     this.playerWalkAnimator = new WalkAnimator();
     this.playerAttackAnimator = new AttackAnimator();
 
-    this.player = new Player(
-      SPAWN_POSITION.x, SPAWN_POSITION.y, SPAWN_POSITION.z,
-      this.world,
-    );
+    this.player = new Player(SPAWN_POSITION.x, SPAWN_POSITION.y, SPAWN_POSITION.z, this.world);
 
     this.blockInteraction = new BlockInteraction(this.world, this.renderer.scene);
 
@@ -186,9 +189,7 @@ export class Game {
       this.player.z = SPAWN_POSITION.z;
       this.player.velocityY = 0;
       this.player.onGround = false;
-      this.renderer.fpsCamera.setPosition(
-        this.player.eyeX, this.player.eyeY, this.player.eyeZ,
-      );
+      this.renderer.fpsCamera.setPosition(this.player.eyeX, this.player.eyeY, this.player.eyeZ);
       this.hud.hideDeathScreen();
     }
 
@@ -208,7 +209,9 @@ export class Game {
 
     // ミニオンウェーブ更新（プレイヤー情報を渡してRedミニオンがプレイヤーを攻撃可能に）
     this.minionWaveManager.update(dt, this.structures, this.world, {
-      x: this.player.x, y: this.player.y, z: this.player.z,
+      x: this.player.x,
+      y: this.player.y,
+      z: this.player.z,
       isAlive: this.playerState.isAlive,
     });
 
@@ -229,7 +232,7 @@ export class Game {
       if (cmd) {
         let target: ProjectileTarget;
         if (cmd.targetId) {
-          const minion = enemyMinions.find(m => m.id === cmd.targetId);
+          const minion = enemyMinions.find((m) => m.id === cmd.targetId);
           target = minion ?? this.playerTarget;
         } else {
           target = this.playerTarget;
@@ -245,7 +248,7 @@ export class Game {
       const dummyPlayer: ProjectileTarget = { x: 0, y: -999, z: 0, isAlive: false };
       const cmd = ai.update(dt, dummyPlayer, enemyMinions);
       if (cmd && cmd.targetId) {
-        const minion = enemyMinions.find(m => m.id === cmd.targetId);
+        const minion = enemyMinions.find((m) => m.id === cmd.targetId);
         if (minion) this.projectileManager.spawn(cmd, minion);
       }
     }
@@ -260,12 +263,16 @@ export class Game {
           triggerFlash(this.playerFlash);
           this.screenShake.trigger();
           this.hud.triggerDamageFlash();
-          const tower = this.towerAIs.find(ai => ai.structure.team === hit.team);
+          const tower = this.towerAIs.find((ai) => ai.structure.team === hit.team);
           if (tower) {
             applyKnockback(
               this.player.knockback,
-              tower.getCenterX(), tower.getCenterY(), tower.getCenterZ(),
-              this.player.x, this.player.y, this.player.z,
+              tower.getCenterX(),
+              tower.getCenterY(),
+              tower.getCenterZ(),
+              this.player.x,
+              this.player.y,
+              this.player.z,
             );
             this.player.velocityY += KNOCKBACK_VERTICAL;
           }
@@ -277,12 +284,16 @@ export class Game {
           minion.takeDamage(hit.damage);
           const kb = this.minionWaveManager.getKnockback(minion.id);
           if (kb) {
-            const tower = this.towerAIs.find(ai => ai.structure.team === hit.team);
+            const tower = this.towerAIs.find((ai) => ai.structure.team === hit.team);
             if (tower) {
               applyKnockback(
                 kb,
-                tower.getCenterX(), tower.getCenterY(), tower.getCenterZ(),
-                minion.x, minion.y, minion.z,
+                tower.getCenterX(),
+                tower.getCenterY(),
+                tower.getCenterZ(),
+                minion.x,
+                minion.y,
+                minion.z,
               );
             }
           }
@@ -306,7 +317,10 @@ export class Game {
 
     // タワー警告HUD
     const inTowerRange = this.towerAIs.some(
-      ai => ai.structure.team !== 'blue' && ai.structure.isAlive && ai.isInRange(this.player.x, this.player.y, this.player.z),
+      (ai) =>
+        ai.structure.team !== 'blue' &&
+        ai.structure.isAlive &&
+        ai.isInRange(this.player.x, this.player.y, this.player.z),
     );
     if (inTowerRange) {
       this.hud.showTowerWarning();
@@ -346,11 +360,24 @@ export class Game {
     // WASD移動
     const forward = this.renderer.fpsCamera.getForward();
     const right = this.renderer.fpsCamera.getRight();
-    let moveX = 0, moveZ = 0;
-    if (this.input.isKeyDown('KeyW')) { moveX += forward.x; moveZ += forward.z; }
-    if (this.input.isKeyDown('KeyS')) { moveX -= forward.x; moveZ -= forward.z; }
-    if (this.input.isKeyDown('KeyA')) { moveX -= right.x; moveZ -= right.z; }
-    if (this.input.isKeyDown('KeyD')) { moveX += right.x; moveZ += right.z; }
+    let moveX = 0,
+      moveZ = 0;
+    if (this.input.isKeyDown('KeyW')) {
+      moveX += forward.x;
+      moveZ += forward.z;
+    }
+    if (this.input.isKeyDown('KeyS')) {
+      moveX -= forward.x;
+      moveZ -= forward.z;
+    }
+    if (this.input.isKeyDown('KeyA')) {
+      moveX -= right.x;
+      moveZ -= right.z;
+    }
+    if (this.input.isKeyDown('KeyD')) {
+      moveX += right.x;
+      moveZ += right.z;
+    }
 
     if (moveX !== 0 || moveZ !== 0) {
       const len = Math.sqrt(moveX * moveX + moveZ * moveZ);
@@ -358,7 +385,7 @@ export class Game {
     }
 
     // 歩行アニメーション
-    const isMoving = (moveX !== 0 || moveZ !== 0);
+    const isMoving = moveX !== 0 || moveZ !== 0;
     const walkAngles = this.playerWalkAnimator.update(dt, isMoving, 4.3);
 
     const applyAngles = (model: THREE.Group, angles: typeof walkAngles) => {
@@ -389,20 +416,32 @@ export class Game {
     const dir = this.getTargetDirection();
 
     const targetStructure = this.combatSystem.findTarget(
-      this.player.eyeX, this.player.eyeY, this.player.eyeZ,
-      dir.x, dir.y, dir.z,
+      this.player.eyeX,
+      this.player.eyeY,
+      this.player.eyeZ,
+      dir.x,
+      dir.y,
+      dir.z,
       this.structures,
     );
 
     const blockHit = this.blockInteraction.update(
-      this.player.eyeX, this.player.eyeY, this.player.eyeZ,
-      dir.x, dir.y, dir.z,
+      this.player.eyeX,
+      this.player.eyeY,
+      this.player.eyeZ,
+      dir.x,
+      dir.y,
+      dir.z,
     );
 
     // ミニオンのレイキャスト判定（球体近似）
     const targetMinion = this.findMinionTarget(
-      this.player.eyeX, this.player.eyeY, this.player.eyeZ,
-      dir.x, dir.y, dir.z,
+      this.player.eyeX,
+      this.player.eyeY,
+      this.player.eyeZ,
+      dir.x,
+      dir.y,
+      dir.z,
     );
 
     const leftClick = this.input.consumeLeftClick();
@@ -452,7 +491,9 @@ export class Game {
 
     if (this.input.consumeRightClick()) {
       if (blockHit) {
-        if (this.blockInteraction.placeBlock(blockHit, this.player.x, this.player.y, this.player.z)) {
+        if (
+          this.blockInteraction.placeBlock(blockHit, this.player.x, this.player.y, this.player.z)
+        ) {
           this.rebuildDirtyChunks();
         }
       }
@@ -516,8 +557,12 @@ export class Game {
 
   /** レイとミニオン（球体近似 半径0.5）の交差判定 */
   private findMinionTarget(
-    ox: number, oy: number, oz: number,
-    dx: number, dy: number, dz: number,
+    ox: number,
+    oy: number,
+    oz: number,
+    dx: number,
+    dy: number,
+    dz: number,
   ): Minion | null {
     let closest: Minion | null = null;
     let closestT = Infinity;
@@ -530,7 +575,9 @@ export class Game {
 
       const radius = 0.5;
       const centerY = m.y + 0.5; // ミニオン中心
-      const ex = m.x - ox, ey = centerY - oy, ez = m.z - oz;
+      const ex = m.x - ox,
+        ey = centerY - oy,
+        ez = m.z - oz;
       const b = ex * dx + ey * dy + ez * dz;
       const c = ex * ex + ey * ey + ez * ez - radius * radius;
       const disc = b * b - c;
@@ -545,7 +592,7 @@ export class Game {
   }
 
   private checkVictory(): void {
-    const redNexus = this.structures.find(s => s.id === 'red-nexus');
+    const redNexus = this.structures.find((s) => s.id === 'red-nexus');
     if (redNexus && !redNexus.isAlive) {
       this.gameOver = true;
       this.hud.hideTarget();
@@ -579,9 +626,8 @@ export class Game {
       old.geometry.dispose();
     }
 
-    const data = buildChunkGeometryData(
-      cx, cy, cz,
-      (wx, wy, wz) => this.world.getBlock(wx, wy, wz),
+    const data = buildChunkGeometryData(cx, cy, cz, (wx, wy, wz) =>
+      this.world.getBlock(wx, wy, wz),
     );
 
     if (data.positions.length === 0) {

--- a/src/entity/CombatSystem.test.ts
+++ b/src/entity/CombatSystem.test.ts
@@ -1,14 +1,40 @@
 import { describe, it, expect } from 'vitest';
-import { CombatSystem, ATTACK_DAMAGE, ATTACK_COOLDOWN, ATTACK_RANGE } from './CombatSystem';
+import { CombatSystem, ATTACK_DAMAGE, ATTACK_COOLDOWN } from './CombatSystem';
 import { Structure } from './Structure';
 import { BlockType } from '../world/Block';
 
 function createRedTower(z: number, protectedBy: Structure | null = null): Structure {
-  return new Structure('red-t', 'red', 8, 4, z, 'tower', 1500, 3, 6, 3, BlockType.RED_TOWER, protectedBy);
+  return new Structure(
+    'red-t',
+    'red',
+    8,
+    4,
+    z,
+    'tower',
+    1500,
+    3,
+    6,
+    3,
+    BlockType.RED_TOWER,
+    protectedBy,
+  );
 }
 
 function createBlueTower(z: number): Structure {
-  return new Structure('blue-t', 'blue', 8, 4, z, 'tower', 1500, 3, 6, 3, BlockType.RED_TOWER, null);
+  return new Structure(
+    'blue-t',
+    'blue',
+    8,
+    4,
+    z,
+    'tower',
+    1500,
+    3,
+    6,
+    3,
+    BlockType.RED_TOWER,
+    null,
+  );
 }
 
 describe('CombatSystem', () => {
@@ -63,7 +89,20 @@ describe('CombatSystem', () => {
 
     it('returns destroyed=true when target dies', () => {
       const cs = new CombatSystem();
-      const target = new Structure('t', 'red', 8, 4, 10, 'tower', ATTACK_DAMAGE, 3, 6, 3, BlockType.RED_TOWER, null);
+      const target = new Structure(
+        't',
+        'red',
+        8,
+        4,
+        10,
+        'tower',
+        ATTACK_DAMAGE,
+        3,
+        6,
+        3,
+        BlockType.RED_TOWER,
+        null,
+      );
       const result = cs.tryAttack(target, 1.0);
       expect(result.hit).toBe(true);
       if (result.hit) {
@@ -93,9 +132,9 @@ describe('CombatSystem', () => {
       const cs = new CombatSystem();
       const far = createRedTower(14);
       far.protectedBy = null;
-      (far as any).id = 'far';
+      (far as unknown as { id: string }).id = 'far';
       const near = createRedTower(10);
-      (near as any).id = 'near';
+      (near as unknown as { id: string }).id = 'near';
       const result = cs.findTarget(9.5, 7, 9, 0, 0, 1, [far, near]);
       expect(result?.id).toBe('near');
     });

--- a/src/entity/CombatSystem.ts
+++ b/src/entity/CombatSystem.ts
@@ -22,10 +22,7 @@ export interface AttackFailed {
 export class CombatSystem {
   private lastAttackTime = 0;
 
-  tryAttack(
-    target: Structure | null,
-    time: number,
-  ): AttackResult | AttackFailed {
+  tryAttack(target: Structure | null, time: number): AttackResult | AttackFailed {
     if (time - this.lastAttackTime < ATTACK_COOLDOWN) {
       return { hit: false, reason: 'cooldown', target: null };
     }
@@ -49,8 +46,12 @@ export class CombatSystem {
   }
 
   findTarget(
-    eyeX: number, eyeY: number, eyeZ: number,
-    dirX: number, dirY: number, dirZ: number,
+    eyeX: number,
+    eyeY: number,
+    eyeZ: number,
+    dirX: number,
+    dirY: number,
+    dirZ: number,
     structures: Structure[],
   ): Structure | null {
     let closest: Structure | null = null;
@@ -60,10 +61,18 @@ export class CombatSystem {
       if (!s.isAlive || s.team === 'blue') continue;
 
       const t = this.rayIntersectsAABB(
-        eyeX, eyeY, eyeZ,
-        dirX, dirY, dirZ,
-        s.x, s.y, s.z,
-        s.x + s.width, s.y + s.height, s.z + s.depth,
+        eyeX,
+        eyeY,
+        eyeZ,
+        dirX,
+        dirY,
+        dirZ,
+        s.x,
+        s.y,
+        s.z,
+        s.x + s.width,
+        s.y + s.height,
+        s.z + s.depth,
       );
 
       if (t !== null && t > 0 && t <= ATTACK_RANGE && t < closestT) {
@@ -76,10 +85,18 @@ export class CombatSystem {
   }
 
   private rayIntersectsAABB(
-    ox: number, oy: number, oz: number,
-    dx: number, dy: number, dz: number,
-    minX: number, minY: number, minZ: number,
-    maxX: number, maxY: number, maxZ: number,
+    ox: number,
+    oy: number,
+    oz: number,
+    dx: number,
+    dy: number,
+    dz: number,
+    minX: number,
+    minY: number,
+    minZ: number,
+    maxX: number,
+    maxY: number,
+    maxZ: number,
   ): number | null {
     let tmin = -Infinity;
     let tmax = Infinity;

--- a/src/entity/Minion.ts
+++ b/src/entity/Minion.ts
@@ -10,8 +10,8 @@ export class Minion extends Entity {
   attackTimer = 0;
 
   // EntityBody fields for EntityPhysics integration
-  readonly width = 0.8;   // slightly larger than player (0.6)
-  readonly height = 1.0;  // sheep height
+  readonly width = 0.8; // slightly larger than player (0.6)
+  readonly height = 1.0; // sheep height
   velocityY = 0;
   onGround = false;
 

--- a/src/entity/MinionAI.test.ts
+++ b/src/entity/MinionAI.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { Minion, MINION_ATTACK_RANGE, MINION_MOVE_SPEED, MINION_ATTACK_INTERVAL, MINION_DAMAGE } from './Minion';
+import {
+  Minion,
+  MINION_ATTACK_RANGE,
+  MINION_MOVE_SPEED,
+  MINION_ATTACK_INTERVAL,
+  MINION_DAMAGE,
+} from './Minion';
 import { MinionAI, LANE_CENTER_X, DETECTION_RANGE, LEASH_RANGE } from './MinionAI';
 import { Structure } from './Structure';
 import { BlockType } from '../world/Block';
@@ -303,7 +309,13 @@ describe('MinionAI State Machine', () => {
     it('prioritizes enemy attacking self over nearest', () => {
       const blue = makeMinion('blue-1', 'blue', LANE_CENTER_X, 0, 50);
       // attackerは少し遠いがDETECTION_RANGE内
-      const redAttacker = makeMinion('red-attacker', 'red', LANE_CENTER_X, 0, 50 + DETECTION_RANGE - 1);
+      const redAttacker = makeMinion(
+        'red-attacker',
+        'red',
+        LANE_CENTER_X,
+        0,
+        50 + DETECTION_RANGE - 1,
+      );
       // nearはもっと近い
       const redNear = makeMinion('red-near', 'red', LANE_CENTER_X, 0, 50 + 2);
       const ai = new MinionAI(blue);

--- a/src/entity/MinionAI.ts
+++ b/src/entity/MinionAI.ts
@@ -12,8 +12,8 @@ export interface PlayerInfo {
 }
 
 export const LANE_CENTER_X = 9.0;
-export const DETECTION_RANGE = 12.0;  // この範囲内の敵を追跡開始
-export const LEASH_RANGE = 16.0;     // この範囲を超えると追跡中止
+export const DETECTION_RANGE = 12.0; // この範囲内の敵を追跡開始
+export const LEASH_RANGE = 16.0; // この範囲を超えると追跡中止
 
 export type MinionAIState = 'walking' | 'chasing' | 'attacking';
 
@@ -125,7 +125,14 @@ export class MinionAI {
           // パス終端に到達 → 再計算
           this.pathTimer = PATH_RECALC_INTERVAL;
         }
-        return { state: 'walking', moveX: 0, moveZ: 0, targetId: null, damage: 0, shouldJump: false };
+        return {
+          state: 'walking',
+          moveX: 0,
+          moveZ: 0,
+          targetId: null,
+          damage: 0,
+          shouldJump: false,
+        };
       }
 
       return this.moveToward(wp.x, wp.z, dt, 'walking');
@@ -288,11 +295,11 @@ export class MinionAI {
     attackingMeId?: string,
     enemyPlayer?: PlayerInfo,
   ): Entity | null {
-    const enemyMinions = allMinions.filter(m => m.team !== this.minion.team && m.isAlive);
+    const enemyMinions = allMinions.filter((m) => m.team !== this.minion.team && m.isAlive);
 
     // 1. 自分を攻撃中の敵（最優先）
     if (attackingMeId) {
-      const attacker = enemyMinions.find(m => m.id === attackingMeId);
+      const attacker = enemyMinions.find((m) => m.id === attackingMeId);
       if (attacker && this.distanceTo(attacker) <= DETECTION_RANGE) {
         return attacker;
       }
@@ -311,7 +318,7 @@ export class MinionAI {
     }
 
     const enemyStructures = structures.filter(
-      s => s.team !== this.minion.team && s.isAlive && !s.isProtected(),
+      (s) => s.team !== this.minion.team && s.isAlive && !s.isProtected(),
     );
     for (const s of enemyStructures) {
       const d = this.distanceTo(s);
@@ -407,7 +414,7 @@ export class MinionAI {
    */
   private findNearestEnemyStructure(structures: Structure[]): Structure | null {
     const enemies = structures.filter(
-      s => s.team !== this.minion.team && s.isAlive && !s.isProtected(),
+      (s) => s.team !== this.minion.team && s.isAlive && !s.isProtected(),
     );
     if (enemies.length === 0) return null;
 
@@ -417,7 +424,7 @@ export class MinionAI {
       const aZ = a.z + a.depth / 2;
       const bZ = b.z + b.depth / 2;
       return direction > 0
-        ? aZ - bZ  // Blue: Z小さい敵構造物が優先（味方側に近い）
+        ? aZ - bZ // Blue: Z小さい敵構造物が優先（味方側に近い）
         : bZ - aZ; // Red: Z大きい敵構造物が優先
     });
     return enemies[0];

--- a/src/entity/MinionWaveManager.test.ts
+++ b/src/entity/MinionWaveManager.test.ts
@@ -1,11 +1,18 @@
 import { describe, it, expect, vi } from 'vitest';
-import { MinionWaveManager, WAVE_INTERVAL, WAVE_SIZE, SPAWN_STAGGER, FIRST_WAVE_DELAY, WorldLike } from './MinionWaveManager';
+import {
+  MinionWaveManager,
+  WAVE_INTERVAL,
+  WAVE_SIZE,
+  SPAWN_STAGGER,
+  FIRST_WAVE_DELAY,
+  WorldLike,
+} from './MinionWaveManager';
 import * as THREE from 'three';
 import { PlayerInfo } from './MinionAI';
 
 /** y<=3 が地面（固体）、それ以外は空気 */
 const mockWorld: WorldLike = {
-  getBlock: (_x: number, y: number, _z: number) => {
+  getBlock: (_x: number, y: number, _z: number): unknown => {
     if (y <= 3) return 1; // ground
     return null;
   },
@@ -167,7 +174,7 @@ describe('DamageFlash integration', () => {
     // After cleanup, triggerMinionFlash should be a no-op (no throw)
     expect(() => manager.triggerMinionFlash(id)).not.toThrow();
     // Minion should be removed from getAllMinions
-    expect(manager.getAllMinions().find(m => m.id === id)).toBeUndefined();
+    expect(manager.getAllMinions().find((m) => m.id === id)).toBeUndefined();
   });
 });
 
@@ -212,9 +219,6 @@ describe('Player-Minion collision', () => {
       manager.update(0.05, [], mockWorld);
     }
 
-    const xBefore = minion.x;
-    const zBefore = minion.z;
-
     // Player is far above (Y difference > 1.0)
     const playerInfo: PlayerInfo = {
       x: minion.x,
@@ -244,9 +248,6 @@ describe('Player-Minion collision', () => {
       manager.update(0.05, [], mockWorld);
     }
 
-    const xBefore = minion.x;
-    const zBefore = minion.z;
-
     // Dead player at same position
     const playerInfo: PlayerInfo = {
       x: minion.x,
@@ -254,10 +255,6 @@ describe('Player-Minion collision', () => {
       z: minion.z,
       isAlive: false,
     };
-
-    // Snapshot position before
-    const snapX = minion.x;
-    const snapZ = minion.z;
 
     manager.update(0.016, [], mockWorld, playerInfo);
 

--- a/src/entity/MinionWaveManager.ts
+++ b/src/entity/MinionWaveManager.ts
@@ -4,10 +4,21 @@ import { MinionAI, PlayerInfo } from './MinionAI';
 import { Structure } from './Structure';
 import { Team } from './Entity';
 import { KnockbackState, createKnockbackState } from '../physics/Knockback';
-import { applyGravity, moveWithCollision, tryJump, applyEntityKnockback } from '../physics/EntityPhysics';
+import {
+  applyGravity,
+  moveWithCollision,
+  tryJump,
+  applyEntityKnockback,
+} from '../physics/EntityPhysics';
 import { WalkAnimator, AttackAnimator } from '../model/Animator';
 import { MINION_MOVE_SPEED } from './Minion';
-import { DamageFlashState, createDamageFlash, triggerFlash, updateFlash, applyFlashToMesh } from '../model/DamageFlash';
+import {
+  DamageFlashState,
+  createDamageFlash,
+  triggerFlash,
+  updateFlash,
+  applyFlashToMesh,
+} from '../model/DamageFlash';
 import { createHealthBar, updateHealthBar } from '../ui/HealthBar3D';
 
 /** EntityPhysicsが要求するWorldの最小インターフェース */
@@ -34,8 +45,8 @@ export class MinionWaveManager {
   private healthBars: Map<string, THREE.Sprite> = new Map();
   private waveTimer = WAVE_INTERVAL - FIRST_WAVE_DELAY; // 最初のウェーブはFIRST_WAVE_DELAY後
   private waveCount = 0;
-  private pendingSpawns = 0;         // 現在のウェーブで未スポーンのミニオン数
-  private spawnStaggerTimer = 0;     // 次のスポーンまでのタイマー
+  private pendingSpawns = 0; // 現在のウェーブで未スポーンのミニオン数
+  private spawnStaggerTimer = 0; // 次のスポーンまでのタイマー
   private pendingPlayerDamage = 0;
 
   constructor(
@@ -75,7 +86,7 @@ export class MinionWaveManager {
       if (!ai) continue;
 
       // AI update — Redミニオンにはプレイヤー（Blue）を敵として渡す
-      const enemyPlayer = (minion.team !== 'blue' && playerInfo) ? playerInfo : undefined;
+      const enemyPlayer = minion.team !== 'blue' && playerInfo ? playerInfo : undefined;
       const result = ai.update(dt, this.minions, this.structures, undefined, enemyPlayer);
 
       // 移動前の位置を記録（auto-jump判定用）
@@ -120,8 +131,9 @@ export class MinionWaveManager {
           // プレイヤーへのダメージはGame.tsで処理するためフラグを立てる
           this.pendingPlayerDamage += result.damage;
         } else {
-          const target = this.minions.find(m => m.id === result.targetId) ??
-            this.structures.find(s => s.id === result.targetId);
+          const target =
+            this.minions.find((m) => m.id === result.targetId) ??
+            this.structures.find((s) => s.id === result.targetId);
           if (target && target.isAlive) {
             target.takeDamage(result.damage);
             // ダメージを受けたミニオンにフラッシュを発動
@@ -151,11 +163,21 @@ export class MinionWaveManager {
           for (const child of mesh.children) {
             const g = child as THREE.Group;
             switch (g.name) {
-              case 'head':          g.rotation.x = angles.head;     break;
-              case 'rightFrontLeg': g.rotation.x = angles.rightArm; break;
-              case 'leftFrontLeg':  g.rotation.x = angles.leftArm;  break;
-              case 'rightBackLeg':  g.rotation.x = angles.rightLeg; break;
-              case 'leftBackLeg':   g.rotation.x = angles.leftLeg;  break;
+              case 'head':
+                g.rotation.x = angles.head;
+                break;
+              case 'rightFrontLeg':
+                g.rotation.x = angles.rightArm;
+                break;
+              case 'leftFrontLeg':
+                g.rotation.x = angles.leftArm;
+                break;
+              case 'rightBackLeg':
+                g.rotation.x = angles.rightLeg;
+                break;
+              case 'leftBackLeg':
+                g.rotation.x = angles.leftLeg;
+                break;
             }
           }
 
@@ -163,7 +185,9 @@ export class MinionWaveManager {
           if (result.state === 'attacking') {
             if (!attackAnim.isPlaying) attackAnim.play();
             const attackAngle = attackAnim.update(dt);
-            const headGroup = mesh.children.find(c => (c as THREE.Group).name === 'head') as THREE.Group;
+            const headGroup = mesh.children.find(
+              (c) => (c as THREE.Group).name === 'head',
+            ) as THREE.Group;
             if (headGroup) headGroup.rotation.x += attackAngle * 0.3;
           }
         }
@@ -246,7 +270,7 @@ export class MinionWaveManager {
     }
 
     // Remove dead minions
-    const dead = this.minions.filter(m => !m.isAlive);
+    const dead = this.minions.filter((m) => !m.isAlive);
     for (const m of dead) {
       const mesh = this.meshes.get(m.id);
       if (mesh) {
@@ -261,7 +285,7 @@ export class MinionWaveManager {
       this.damageFlashes.delete(m.id);
       this.healthBars.delete(m.id);
     }
-    this.minions = this.minions.filter(m => m.isAlive);
+    this.minions = this.minions.filter((m) => m.isAlive);
   }
 
   /** 1体のミニオンをスポーンする（全て同じ位置から出発） */
@@ -301,8 +325,12 @@ export class MinionWaveManager {
     this.attackAnimators.set(id, new AttackAnimator());
   }
 
-  getAllMinions(): Minion[] { return this.minions; }
-  getTeamMinions(team: Team): Minion[] { return this.minions.filter(m => m.team === team); }
+  getAllMinions(): Minion[] {
+    return this.minions;
+  }
+  getTeamMinions(team: Team): Minion[] {
+    return this.minions.filter((m) => m.team === team);
+  }
 
   getKnockback(id: string): KnockbackState | undefined {
     return this.knockbacks.get(id);

--- a/src/entity/Projectile.test.ts
+++ b/src/entity/Projectile.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { Projectile, PROJECTILE_SPEED, PROJECTILE_RADIUS, PROJECTILE_MAX_LIFETIME, PLAYER_HIT_RADIUS, PROJECTILE_TURN_RATE } from './Projectile';
+import {
+  Projectile,
+  PROJECTILE_SPEED,
+  PROJECTILE_RADIUS,
+  PROJECTILE_MAX_LIFETIME,
+  PLAYER_HIT_RADIUS,
+} from './Projectile';
 
 describe('Projectile', () => {
   it('initial state: alive=true, at origin position', () => {
@@ -69,7 +75,6 @@ describe('Projectile', () => {
     const target = { x: 0, y: 0, z: 100, isAlive: true };
     const p = new Projectile(0, 0, 0, 25, 'red', target);
     // 1フレーム(16ms)で旋回可能な最大角度
-    const maxAnglePerFrame = PROJECTILE_TURN_RATE * 0.016;
     target.x = 100;
     target.z = 0;
     p.update(0.016); // ターゲットは90度横

--- a/src/entity/Projectile.ts
+++ b/src/entity/Projectile.ts
@@ -27,8 +27,14 @@ export class Projectile {
   private dirY: number;
   private dirZ: number;
 
-  constructor(x: number, y: number, z: number, damage: number, team: Team,
-    target: ProjectileTarget) {
+  constructor(
+    x: number,
+    y: number,
+    z: number,
+    damage: number,
+    team: Team,
+    target: ProjectileTarget,
+  ) {
     this.x = x;
     this.y = y;
     this.z = z;
@@ -86,8 +92,10 @@ export class Projectile {
     const desiredZ = dz / dist;
 
     // 現在方向と目標方向の角度差
-    const dot = Math.max(-1, Math.min(1,
-      this.dirX * desiredX + this.dirY * desiredY + this.dirZ * desiredZ));
+    const dot = Math.max(
+      -1,
+      Math.min(1, this.dirX * desiredX + this.dirY * desiredY + this.dirZ * desiredZ),
+    );
     const angle = Math.acos(dot);
 
     // 旋回制限付きで方向を補間
@@ -95,9 +103,9 @@ export class Projectile {
       const maxTurn = PROJECTILE_TURN_RATE * dt;
       const t = Math.min(1, maxTurn / angle);
       // 線形補間 + 再正規化
-      let newX = this.dirX + (desiredX - this.dirX) * t;
-      let newY = this.dirY + (desiredY - this.dirY) * t;
-      let newZ = this.dirZ + (desiredZ - this.dirZ) * t;
+      const newX = this.dirX + (desiredX - this.dirX) * t;
+      const newY = this.dirY + (desiredY - this.dirY) * t;
+      const newZ = this.dirZ + (desiredZ - this.dirZ) * t;
       const len = Math.sqrt(newX * newX + newY * newY + newZ * newZ);
       if (len > 0) {
         this.dirX = newX / len;

--- a/src/entity/ProjectileManager.test.ts
+++ b/src/entity/ProjectileManager.test.ts
@@ -5,8 +5,16 @@ import { PROJECTILE_MAX_LIFETIME } from './Projectile';
 
 vi.mock('three', () => {
   class MockVector3 {
-    constructor(public x = 0, public y = 0, public z = 0) {}
-    set(x: number, y: number, z: number) { this.x = x; this.y = y; this.z = z; }
+    constructor(
+      public x = 0,
+      public y = 0,
+      public z = 0,
+    ) {}
+    set(x: number, y: number, z: number) {
+      this.x = x;
+      this.y = y;
+      this.z = z;
+    }
   }
   class MockMesh {
     position = new MockVector3();
@@ -15,9 +23,11 @@ vi.mock('three', () => {
   class MockSphereGeometry {}
   class MockMeshStandardMaterial {}
   class MockScene {
-    children: any[] = [];
-    add(obj: any) { this.children.push(obj); }
-    remove(obj: any) {
+    children: unknown[] = [];
+    add(obj: unknown) {
+      this.children.push(obj);
+    }
+    remove(obj: unknown) {
       const i = this.children.indexOf(obj);
       if (i >= 0) this.children.splice(i, 1);
     }
@@ -77,8 +87,14 @@ describe('ProjectileManager', () => {
   });
 
   it('dispose removes all projectiles', () => {
-    manager.spawn({ originX: 0, originY: 0, originZ: 0, damage: 25, team: 'red' }, { x: 100, y: 0, z: 0, isAlive: true });
-    manager.spawn({ originX: 5, originY: 0, originZ: 0, damage: 25, team: 'red' }, { x: 100, y: 0, z: 0, isAlive: true });
+    manager.spawn(
+      { originX: 0, originY: 0, originZ: 0, damage: 25, team: 'red' },
+      { x: 100, y: 0, z: 0, isAlive: true },
+    );
+    manager.spawn(
+      { originX: 5, originY: 0, originZ: 0, damage: 25, team: 'red' },
+      { x: 100, y: 0, z: 0, isAlive: true },
+    );
     expect(scene.children.length).toBe(2);
     manager.dispose();
     expect(scene.children.length).toBe(0);

--- a/src/entity/ProjectileManager.ts
+++ b/src/entity/ProjectileManager.ts
@@ -17,8 +17,12 @@ export class ProjectileManager {
 
   spawn(command: FireCommand, target: ProjectileTarget): void {
     const projectile = new Projectile(
-      command.originX, command.originY, command.originZ,
-      command.damage, command.team, target,
+      command.originX,
+      command.originY,
+      command.originZ,
+      command.damage,
+      command.team,
+      target,
     );
     this.projectiles.push(projectile);
 
@@ -45,7 +49,7 @@ export class ProjectileManager {
       }
     }
 
-    const dead = this.projectiles.filter(p => !p.alive);
+    const dead = this.projectiles.filter((p) => !p.alive);
     for (const p of dead) {
       const mesh = this.meshes.get(p);
       if (mesh) {
@@ -54,7 +58,7 @@ export class ProjectileManager {
         this.meshes.delete(p);
       }
     }
-    this.projectiles = this.projectiles.filter(p => p.alive);
+    this.projectiles = this.projectiles.filter((p) => p.alive);
 
     for (const p of this.projectiles) {
       const mesh = this.meshes.get(p);

--- a/src/entity/Structure.test.ts
+++ b/src/entity/Structure.test.ts
@@ -3,11 +3,21 @@ import { Structure } from './Structure';
 import { World } from '../world/World';
 import { BlockType } from '../world/Block';
 
-function createTower(id: string, team: 'blue' | 'red', z: number, protectedBy: Structure | null = null): Structure {
+function createTower(
+  id: string,
+  team: 'blue' | 'red',
+  z: number,
+  protectedBy: Structure | null = null,
+): Structure {
   return new Structure(id, team, 8, 4, z, 'tower', 1500, 3, 6, 3, BlockType.RED_TOWER, protectedBy);
 }
 
-function createNexus(id: string, team: 'blue' | 'red', z: number, protectedBy: Structure | null = null): Structure {
+function createNexus(
+  id: string,
+  team: 'blue' | 'red',
+  z: number,
+  protectedBy: Structure | null = null,
+): Structure {
   return new Structure(id, team, 7, 4, z, 'nexus', 3000, 5, 4, 5, BlockType.RED_NEXUS, protectedBy);
 }
 

--- a/src/entity/TowerAI.test.ts
+++ b/src/entity/TowerAI.test.ts
@@ -5,7 +5,20 @@ import { BlockType } from '../world/Block';
 import { Minion } from './Minion';
 
 function makeTower(team: 'blue' | 'red' = 'red', x = 8, y = 4, z = 136): Structure {
-  return new Structure('test-tower', team, x, y, z, 'tower', 1500, 3, 6, 3, BlockType.RED_TOWER, null);
+  return new Structure(
+    'test-tower',
+    team,
+    x,
+    y,
+    z,
+    'tower',
+    1500,
+    3,
+    6,
+    3,
+    BlockType.RED_TOWER,
+    null,
+  );
 }
 
 function makeMinion(id: string, team: 'blue' | 'red', x: number, y: number, z: number): Minion {
@@ -39,7 +52,11 @@ describe('TowerAI', () => {
   it('fires after attack interval when in range', () => {
     const ai = new TowerAI(makeTower());
     const targetZ = 137.5 + 5;
-    const result1 = ai.update(TOWER_ATTACK_INTERVAL - 0.01, { x: 9.5, y: 7, z: targetZ, isAlive: true }, []);
+    const result1 = ai.update(
+      TOWER_ATTACK_INTERVAL - 0.01,
+      { x: 9.5, y: 7, z: targetZ, isAlive: true },
+      [],
+    );
     expect(result1).toBeNull();
     const result2 = ai.update(0.02, { x: 9.5, y: 7, z: targetZ, isAlive: true }, []);
     expect(result2).not.toBeNull();
@@ -53,7 +70,11 @@ describe('TowerAI', () => {
   it('returns null when target out of range', () => {
     const ai = new TowerAI(makeTower());
     const farZ = 137.5 + TOWER_ATTACK_RANGE + 10;
-    const result = ai.update(TOWER_ATTACK_INTERVAL + 1, { x: 9.5, y: 7, z: farZ, isAlive: true }, []);
+    const result = ai.update(
+      TOWER_ATTACK_INTERVAL + 1,
+      { x: 9.5, y: 7, z: farZ, isAlive: true },
+      [],
+    );
     expect(result).toBeNull();
   });
 
@@ -62,13 +83,21 @@ describe('TowerAI', () => {
     tower.hp = 0;
     tower.isAlive = false;
     const ai = new TowerAI(tower);
-    const result = ai.update(TOWER_ATTACK_INTERVAL + 1, { x: 9.5, y: 7, z: 137.5, isAlive: true }, []);
+    const result = ai.update(
+      TOWER_ATTACK_INTERVAL + 1,
+      { x: 9.5, y: 7, z: 137.5, isAlive: true },
+      [],
+    );
     expect(result).toBeNull();
   });
 
   it('returns null when target is dead', () => {
     const ai = new TowerAI(makeTower());
-    const result = ai.update(TOWER_ATTACK_INTERVAL + 1, { x: 9.5, y: 7, z: 137.5 + 5, isAlive: false }, []);
+    const result = ai.update(
+      TOWER_ATTACK_INTERVAL + 1,
+      { x: 9.5, y: 7, z: 137.5 + 5, isAlive: false },
+      [],
+    );
     expect(result).toBeNull();
   });
 

--- a/src/entity/TowerAI.ts
+++ b/src/entity/TowerAI.ts
@@ -37,11 +37,15 @@ export class TowerAI {
       const dy = m.y - this.getCenterY();
       const dz = m.z - this.getCenterZ();
       const d = Math.sqrt(dx * dx + dy * dy + dz * dz);
-      if (d < minDist) { minDist = d; minionTarget = m; }
+      if (d < minDist) {
+        minDist = d;
+        minionTarget = m;
+      }
     }
 
     // 2. If no minion, check player
-    const hasTarget = minionTarget !== null ||
+    const hasTarget =
+      minionTarget !== null ||
       (playerTarget.isAlive && this.isInRange(playerTarget.x, playerTarget.y, playerTarget.z));
 
     if (!hasTarget) {

--- a/src/model/Animator.ts
+++ b/src/model/Animator.ts
@@ -1,4 +1,4 @@
-export const WALK_AMPLITUDE = 0.5;     // ラジアン
+export const WALK_AMPLITUDE = 0.5; // ラジアン
 export const WALK_SPEED_FACTOR = 8.0;
 const IDLE_AMPLITUDE = 0.02;
 const IDLE_SPEED = 1.5;
@@ -47,10 +47,15 @@ export class AttackAnimator {
   update(dt: number): number {
     if (!this.active) return 0;
     this.timer -= dt;
-    if (this.timer <= 0) { this.active = false; return 0; }
+    if (this.timer <= 0) {
+      this.active = false;
+      return 0;
+    }
     const progress = 1 - this.timer / AttackAnimator.DURATION;
     return -Math.sin(progress * Math.PI) * 1.5;
   }
 
-  get isPlaying(): boolean { return this.active; }
+  get isPlaying(): boolean {
+    return this.active;
+  }
 }

--- a/src/model/MobModel.test.ts
+++ b/src/model/MobModel.test.ts
@@ -24,7 +24,7 @@ describe('buildModel', () => {
 
   it('names parts correctly for player model', () => {
     const group = buildModel(PLAYER_MODEL, createTestTexture());
-    const names = group.children.map(c => c.name);
+    const names = group.children.map((c) => c.name);
     expect(names).toContain('head');
     expect(names).toContain('body');
     expect(names).toContain('rightArm');
@@ -35,7 +35,7 @@ describe('buildModel', () => {
 
   it('sets pivot positions with correct scale', () => {
     const group = buildModel(PLAYER_MODEL, createTestTexture());
-    const head = group.children.find(c => c.name === 'head')!;
+    const head = group.children.find((c) => c.name === 'head')!;
     const scale = PLAYER_MODEL.pixelScale;
     expect(head.position.x).toBeCloseTo(0 * scale);
     expect(head.position.y).toBeCloseTo(24 * scale);
@@ -47,19 +47,19 @@ describe('buildModel', () => {
     const scale = PLAYER_MODEL.pixelScale;
 
     // head: offset=[0, 4, 0] → mesh.position.y = 4 * scale
-    const headPivot = group.children.find(c => c.name === 'head')! as THREE.Group;
+    const headPivot = group.children.find((c) => c.name === 'head')! as THREE.Group;
     const headMesh = headPivot.children[0] as THREE.Mesh;
     expect(headMesh.position.y).toBeCloseTo(4 * scale);
 
     // rightArm: offset=[0, -6, 0] → mesh.position.y = -6 * scale
-    const armPivot = group.children.find(c => c.name === 'rightArm')! as THREE.Group;
+    const armPivot = group.children.find((c) => c.name === 'rightArm')! as THREE.Group;
     const armMesh = armPivot.children[0] as THREE.Mesh;
     expect(armMesh.position.y).toBeCloseTo(-6 * scale);
   });
 
   it('applies initialRotation to sheep body pivot group', () => {
     const group = buildModel(SHEEP_MODEL, createTestTexture());
-    const body = group.children.find(c => c.name === 'body')! as THREE.Group;
+    const body = group.children.find((c) => c.name === 'body')! as THREE.Group;
     expect(body.rotation.x).toBeCloseTo(-Math.PI / 2);
     expect(body.rotation.y).toBeCloseTo(0);
     expect(body.rotation.z).toBeCloseTo(0);
@@ -67,7 +67,7 @@ describe('buildModel', () => {
 
   it('does not apply rotation to parts without initialRotation', () => {
     const group = buildModel(SHEEP_MODEL, createTestTexture());
-    const head = group.children.find(c => c.name === 'head')! as THREE.Group;
+    const head = group.children.find((c) => c.name === 'head')! as THREE.Group;
     expect(head.rotation.x).toBeCloseTo(0);
     expect(head.rotation.y).toBeCloseTo(0);
     expect(head.rotation.z).toBeCloseTo(0);

--- a/src/model/MobModel.ts
+++ b/src/model/MobModel.ts
@@ -6,11 +6,20 @@ import { computeFaceUVs } from './SkinParser';
  * BoxGeometryの各面にMinecraftスキンのUVを適用する。
  * Three.js BoxGeometryの面順序: +x(right), -x(left), +y(top), -y(bottom), +z(front), -z(back)
  */
-function applyFaceUVs(geometry: THREE.BoxGeometry, part: PartDefinition, texW: number, texH: number): void {
+function applyFaceUVs(
+  geometry: THREE.BoxGeometry,
+  part: PartDefinition,
+  texW: number,
+  texH: number,
+): void {
   const uvs = computeFaceUVs(
-    part.skinRegion.originX, part.skinRegion.originY,
-    part.skinRegion.w, part.skinRegion.h, part.skinRegion.d,
-    texW, texH,
+    part.skinRegion.originX,
+    part.skinRegion.originY,
+    part.skinRegion.w,
+    part.skinRegion.h,
+    part.skinRegion.d,
+    texW,
+    texH,
   );
 
   const uvAttr = geometry.getAttribute('uv') as THREE.BufferAttribute;
@@ -21,10 +30,14 @@ function applyFaceUVs(geometry: THREE.BoxGeometry, part: PartDefinition, texW: n
   for (let face = 0; face < 6; face++) {
     const faceUV = faceOrder[face];
     const base = face * 8;
-    arr[base + 0] = faceUV.u;              arr[base + 1] = 1 - faceUV.v;
-    arr[base + 2] = faceUV.u + faceUV.w;   arr[base + 3] = 1 - faceUV.v;
-    arr[base + 4] = faceUV.u;              arr[base + 5] = 1 - (faceUV.v + faceUV.h);
-    arr[base + 6] = faceUV.u + faceUV.w;   arr[base + 7] = 1 - (faceUV.v + faceUV.h);
+    arr[base + 0] = faceUV.u;
+    arr[base + 1] = 1 - faceUV.v;
+    arr[base + 2] = faceUV.u + faceUV.w;
+    arr[base + 3] = 1 - faceUV.v;
+    arr[base + 4] = faceUV.u;
+    arr[base + 5] = 1 - (faceUV.v + faceUV.h);
+    arr[base + 6] = faceUV.u + faceUV.w;
+    arr[base + 7] = 1 - (faceUV.v + faceUV.h);
   }
   uvAttr.needsUpdate = true;
 }
@@ -48,19 +61,11 @@ export function buildModel(def: ModelDefinition, texture: THREE.Texture): THREE.
     applyFaceUVs(geometry, part, def.textureWidth, def.textureHeight);
 
     const mesh = new THREE.Mesh(geometry, material);
-    mesh.position.set(
-      part.offset[0] * scale,
-      part.offset[1] * scale,
-      part.offset[2] * scale,
-    );
+    mesh.position.set(part.offset[0] * scale, part.offset[1] * scale, part.offset[2] * scale);
 
     const pivotGroup = new THREE.Group();
     pivotGroup.name = part.name;
-    pivotGroup.position.set(
-      part.pivot[0] * scale,
-      part.pivot[1] * scale,
-      part.pivot[2] * scale,
-    );
+    pivotGroup.position.set(part.pivot[0] * scale, part.pivot[1] * scale, part.pivot[2] * scale);
 
     if (part.initialRotation) {
       pivotGroup.rotation.set(

--- a/src/model/ModelDefinitions.test.ts
+++ b/src/model/ModelDefinitions.test.ts
@@ -3,14 +3,14 @@ import { SHEEP_MODEL, PLAYER_MODEL } from './ModelDefinitions';
 
 describe('SHEEP_MODEL Minecraft compliance', () => {
   it('head has wool dimensions (ModelSheep1: 6,6,6 + 0.6 inflation = 7.2)', () => {
-    const head = SHEEP_MODEL.parts.find(p => p.name === 'head')!;
+    const head = SHEEP_MODEL.parts.find((p) => p.name === 'head')!;
     expect(head.size).toEqual([7.2, 7.2, 7.2]);
     // UV座標はModelSheep2のスキンレイアウト準拠
     expect(head.skinRegion).toMatchObject({ originX: 0, originY: 0, w: 6, h: 6, d: 8 });
   });
 
   it('body has wool dimensions (ModelSheep1: 8,16,6 + 1.75 inflation = 11.5,19.5,9.5)', () => {
-    const body = SHEEP_MODEL.parts.find(p => p.name === 'body')!;
+    const body = SHEEP_MODEL.parts.find((p) => p.name === 'body')!;
     expect(body.size).toEqual([11.5, 19.5, 9.5]);
     expect(body.skinRegion).toMatchObject({ originX: 28, originY: 8, w: 8, h: 16, d: 6 });
   });
@@ -27,13 +27,13 @@ describe('SHEEP_MODEL Minecraft compliance', () => {
 
   // MC座標変換の検証: pivot = (mcX, 24-mcY, -mcZ)
   it('head pivot converts from MC rotationPoint(0,6,-8)', () => {
-    const head = SHEEP_MODEL.parts.find(p => p.name === 'head')!;
+    const head = SHEEP_MODEL.parts.find((p) => p.name === 'head')!;
     // threeX=0, threeY=24-6=18, threeZ=-(-8)=8
     expect(head.pivot).toEqual([0, 18, 8]);
   });
 
   it('body pivot converts from MC rotationPoint(0,5,2) with PI/2 rotation', () => {
-    const body = SHEEP_MODEL.parts.find(p => p.name === 'body')!;
+    const body = SHEEP_MODEL.parts.find((p) => p.name === 'body')!;
     // threeX=0, threeY=24-5=19, threeZ=-(2)=-2
     expect(body.pivot).toEqual([0, 19, -2]);
     expect(body.initialRotation).toBeDefined();
@@ -41,10 +41,10 @@ describe('SHEEP_MODEL Minecraft compliance', () => {
   });
 
   it('leg pivots convert from MC rotationPoints correctly', () => {
-    const rfLeg = SHEEP_MODEL.parts.find(p => p.name === 'rightFrontLeg')!;
-    const lfLeg = SHEEP_MODEL.parts.find(p => p.name === 'leftFrontLeg')!;
-    const rbLeg = SHEEP_MODEL.parts.find(p => p.name === 'rightBackLeg')!;
-    const lbLeg = SHEEP_MODEL.parts.find(p => p.name === 'leftBackLeg')!;
+    const rfLeg = SHEEP_MODEL.parts.find((p) => p.name === 'rightFrontLeg')!;
+    const lfLeg = SHEEP_MODEL.parts.find((p) => p.name === 'leftFrontLeg')!;
+    const rbLeg = SHEEP_MODEL.parts.find((p) => p.name === 'rightBackLeg')!;
+    const lbLeg = SHEEP_MODEL.parts.find((p) => p.name === 'leftBackLeg')!;
 
     // rightFront: MC(-3,12,-5) → (-3, 12, 5)
     expect(rfLeg.pivot).toEqual([-3, 12, 5]);
@@ -57,20 +57,20 @@ describe('SHEEP_MODEL Minecraft compliance', () => {
   });
 
   it('head offset converts from MC addBox(-3,-4,-4, 6,6,6, 0.6)', () => {
-    const head = SHEEP_MODEL.parts.find(p => p.name === 'head')!;
+    const head = SHEEP_MODEL.parts.find((p) => p.name === 'head')!;
     // MC center = (0, -1, -1), Three.js offset = (0, 1, 1)
     expect(head.offset).toEqual([0, 1, 1]);
   });
 
   it('body offset converts from MC addBox(-4,-10,-7, 8,16,6) with -PI/2 X rotation', () => {
-    const body = SHEEP_MODEL.parts.find(p => p.name === 'body')!;
+    const body = SHEEP_MODEL.parts.find((p) => p.name === 'body')!;
     // mcBoxCenter=(0,-2,-4), worldOffset=(0,2,4), localInverse(-PI/2 X): (0,-4,2)
     // visual adjustment: +3 back (localY+3), -4 down (localZ-4) from (0,-4,2)
     expect(body.offset).toEqual([0, -1, -2]);
   });
 
   it('leg offsets convert from MC addBox(-2,0,-2, 4,6,4, 0.5)', () => {
-    const leg = SHEEP_MODEL.parts.find(p => p.name === 'rightFrontLeg')!;
+    const leg = SHEEP_MODEL.parts.find((p) => p.name === 'rightFrontLeg')!;
     // MC center = (0, 3, 0), Three.js offset = (0, -3, 0)
     expect(leg.offset).toEqual([0, -3, 0]);
   });
@@ -85,20 +85,20 @@ describe('SHEEP_MODEL Minecraft compliance', () => {
 
 describe('PLAYER_MODEL offset migration', () => {
   it('head pivot and offset', () => {
-    const head = PLAYER_MODEL.parts.find(p => p.name === 'head')!;
+    const head = PLAYER_MODEL.parts.find((p) => p.name === 'head')!;
     expect(head.pivot).toEqual([0, 24, 0]);
     expect(head.offset).toEqual([0, 4, 0]);
   });
 
   it('body pivot and offset', () => {
-    const body = PLAYER_MODEL.parts.find(p => p.name === 'body')!;
+    const body = PLAYER_MODEL.parts.find((p) => p.name === 'body')!;
     expect(body.pivot).toEqual([0, 12, 0]);
     expect(body.offset).toEqual([0, 6, 0]);
   });
 
   it('limbs use offset=[0,-6,0] (was anchor=top/default, h=12)', () => {
     for (const name of ['rightArm', 'leftArm', 'rightLeg', 'leftLeg']) {
-      const part = PLAYER_MODEL.parts.find(p => p.name === name)!;
+      const part = PLAYER_MODEL.parts.find((p) => p.name === name)!;
       expect(part.offset).toEqual([0, -6, 0]);
     }
   });

--- a/src/model/ModelDefinitions.ts
+++ b/src/model/ModelDefinitions.ts
@@ -12,9 +12,9 @@ export interface SkinRegion {
 /** 1パーツの定義 */
 export interface PartDefinition {
   name: string;
-  size: [number, number, number];    // [w, h, d] ピクセル単位
-  pivot: [number, number, number];   // 回転軸の位置（ピクセル単位、Three.js座標系）
-  offset: [number, number, number];  // ピボットからのメッシュ中心オフセット（ピクセル単位、Three.js座標系）
+  size: [number, number, number]; // [w, h, d] ピクセル単位
+  pivot: [number, number, number]; // 回転軸の位置（ピクセル単位、Three.js座標系）
+  offset: [number, number, number]; // ピボットからのメッシュ中心オフセット（ピクセル単位、Three.js座標系）
   skinRegion: SkinRegion;
   /** パーツの初期回転 [rx, ry, rz] ラジアン（例: 体のX軸90度回転） */
   initialRotation?: [number, number, number];
@@ -39,12 +39,48 @@ export const PLAYER_MODEL: ModelDefinition = {
   forwardAngle: 0,
   parts: [
     // anchor='bottom' → offset=[0, h/2, 0], anchor='top'(default) → offset=[0, -h/2, 0]
-    { name: 'head',     size: [8, 8, 8],   pivot: [0, 24, 0],   offset: [0, 4, 0],   skinRegion: { originX: 0,  originY: 0,  w: 8, h: 8, d: 8 } },
-    { name: 'body',     size: [8, 12, 4],  pivot: [0, 12, 0],   offset: [0, 6, 0],   skinRegion: { originX: 16, originY: 16, w: 8, h: 12, d: 4 } },
-    { name: 'rightArm', size: [4, 12, 4],  pivot: [-6, 24, 0],  offset: [0, -6, 0],  skinRegion: { originX: 40, originY: 16, w: 4, h: 12, d: 4 } },
-    { name: 'leftArm',  size: [4, 12, 4],  pivot: [6, 24, 0],   offset: [0, -6, 0],  skinRegion: { originX: 32, originY: 48, w: 4, h: 12, d: 4 } },
-    { name: 'rightLeg', size: [4, 12, 4],  pivot: [-2, 12, 0],  offset: [0, -6, 0],  skinRegion: { originX: 0,  originY: 16, w: 4, h: 12, d: 4 } },
-    { name: 'leftLeg',  size: [4, 12, 4],  pivot: [2, 12, 0],   offset: [0, -6, 0],  skinRegion: { originX: 16, originY: 48, w: 4, h: 12, d: 4 } },
+    {
+      name: 'head',
+      size: [8, 8, 8],
+      pivot: [0, 24, 0],
+      offset: [0, 4, 0],
+      skinRegion: { originX: 0, originY: 0, w: 8, h: 8, d: 8 },
+    },
+    {
+      name: 'body',
+      size: [8, 12, 4],
+      pivot: [0, 12, 0],
+      offset: [0, 6, 0],
+      skinRegion: { originX: 16, originY: 16, w: 8, h: 12, d: 4 },
+    },
+    {
+      name: 'rightArm',
+      size: [4, 12, 4],
+      pivot: [-6, 24, 0],
+      offset: [0, -6, 0],
+      skinRegion: { originX: 40, originY: 16, w: 4, h: 12, d: 4 },
+    },
+    {
+      name: 'leftArm',
+      size: [4, 12, 4],
+      pivot: [6, 24, 0],
+      offset: [0, -6, 0],
+      skinRegion: { originX: 32, originY: 48, w: 4, h: 12, d: 4 },
+    },
+    {
+      name: 'rightLeg',
+      size: [4, 12, 4],
+      pivot: [-2, 12, 0],
+      offset: [0, -6, 0],
+      skinRegion: { originX: 0, originY: 16, w: 4, h: 12, d: 4 },
+    },
+    {
+      name: 'leftLeg',
+      size: [4, 12, 4],
+      pivot: [2, 12, 0],
+      offset: [0, -6, 0],
+      skinRegion: { originX: 16, originY: 48, w: 4, h: 12, d: 4 },
+    },
   ],
 };
 
@@ -92,16 +128,53 @@ export const SHEEP_MODEL: ModelDefinition = {
     // Head: ModelSheep1 addBox(-3,-4,-4, 6,6,6, 0.6) → 実効 7.2×7.2×7.2
     // rotationPoint(0,6,-8) → pivot(0, 18, 8)
     // mcCenter=(0,-1,-1) → offset(0, 1, 1)
-    { name: 'head',          size: [7.2, 7.2, 7.2], pivot: [0, 18, 8],   offset: [0, 1, 1],    skinRegion: { originX: 0,  originY: 0,  w: 6, h: 6, d: 8 } },
+    {
+      name: 'head',
+      size: [7.2, 7.2, 7.2],
+      pivot: [0, 18, 8],
+      offset: [0, 1, 1],
+      skinRegion: { originX: 0, originY: 0, w: 6, h: 6, d: 8 },
+    },
     // Body: ModelSheep1 addBox(-4,-10,-7, 8,16,6, 1.75) → 実効 11.5×19.5×9.5
     // rotationPoint(0,5,2) → pivot(0, 19, -2), rotX → -PI/2
     // mcCenter=(0,-2,-4) → worldOffset(0,2,4) → local(0,-4,2)
-    { name: 'body',          size: [11.5, 19.5, 9.5], pivot: [0, 19, -2],  offset: [0, -1, -2],  skinRegion: { originX: 28, originY: 8,  w: 8, h: 16, d: 6 }, initialRotation: [-Math.PI / 2, 0, 0] },
+    {
+      name: 'body',
+      size: [11.5, 19.5, 9.5],
+      pivot: [0, 19, -2],
+      offset: [0, -1, -2],
+      skinRegion: { originX: 28, originY: 8, w: 8, h: 16, d: 6 },
+      initialRotation: [-Math.PI / 2, 0, 0],
+    },
     // Legs: ModelSheep1 addBox(-2,0,-2, 4,6,4, 0.5) → 実効 5×7×5
     // mcCenter=(0,3,0) → offset(0,-3,0)
-    { name: 'rightFrontLeg', size: [5, 7, 5],   pivot: [-3, 12, 5],  offset: [0, -3, 0],   skinRegion: { originX: 0,  originY: 16, w: 4, h: 12, d: 4 } },
-    { name: 'leftFrontLeg',  size: [5, 7, 5],   pivot: [3, 12, 5],   offset: [0, -3, 0],   skinRegion: { originX: 0,  originY: 16, w: 4, h: 12, d: 4 } },
-    { name: 'rightBackLeg',  size: [5, 7, 5],   pivot: [-3, 12, -7], offset: [0, -3, 0],   skinRegion: { originX: 0,  originY: 16, w: 4, h: 12, d: 4 } },
-    { name: 'leftBackLeg',   size: [5, 7, 5],   pivot: [3, 12, -7],  offset: [0, -3, 0],   skinRegion: { originX: 0,  originY: 16, w: 4, h: 12, d: 4 } },
+    {
+      name: 'rightFrontLeg',
+      size: [5, 7, 5],
+      pivot: [-3, 12, 5],
+      offset: [0, -3, 0],
+      skinRegion: { originX: 0, originY: 16, w: 4, h: 12, d: 4 },
+    },
+    {
+      name: 'leftFrontLeg',
+      size: [5, 7, 5],
+      pivot: [3, 12, 5],
+      offset: [0, -3, 0],
+      skinRegion: { originX: 0, originY: 16, w: 4, h: 12, d: 4 },
+    },
+    {
+      name: 'rightBackLeg',
+      size: [5, 7, 5],
+      pivot: [-3, 12, -7],
+      offset: [0, -3, 0],
+      skinRegion: { originX: 0, originY: 16, w: 4, h: 12, d: 4 },
+    },
+    {
+      name: 'leftBackLeg',
+      size: [5, 7, 5],
+      pivot: [3, 12, -7],
+      offset: [0, -3, 0],
+      skinRegion: { originX: 0, originY: 16, w: 4, h: 12, d: 4 },
+    },
   ],
 };

--- a/src/model/SkinParser.test.ts
+++ b/src/model/SkinParser.test.ts
@@ -7,22 +7,22 @@ describe('computeFaceUVs', () => {
 
   it('computes head face UVs (8x8x8 at origin 0,0)', () => {
     const uvs = computeFaceUVs(0, 0, 8, 8, 8, TEX_W, TEX_H);
-    expect(uvs.top).toEqual({ u: 8/64, v: 0/64, w: 8/64, h: 8/64 });
-    expect(uvs.front).toEqual({ u: 8/64, v: 8/64, w: 8/64, h: 8/64 });
-    expect(uvs.right).toEqual({ u: 16/64, v: 8/64, w: 8/64, h: 8/64 });
-    expect(uvs.left).toEqual({ u: 0/64, v: 8/64, w: 8/64, h: 8/64 });
-    expect(uvs.back).toEqual({ u: 24/64, v: 8/64, w: 8/64, h: 8/64 });
-    expect(uvs.bottom).toEqual({ u: 16/64, v: 0/64, w: 8/64, h: 8/64 });
+    expect(uvs.top).toEqual({ u: 8 / 64, v: 0 / 64, w: 8 / 64, h: 8 / 64 });
+    expect(uvs.front).toEqual({ u: 8 / 64, v: 8 / 64, w: 8 / 64, h: 8 / 64 });
+    expect(uvs.right).toEqual({ u: 16 / 64, v: 8 / 64, w: 8 / 64, h: 8 / 64 });
+    expect(uvs.left).toEqual({ u: 0 / 64, v: 8 / 64, w: 8 / 64, h: 8 / 64 });
+    expect(uvs.back).toEqual({ u: 24 / 64, v: 8 / 64, w: 8 / 64, h: 8 / 64 });
+    expect(uvs.bottom).toEqual({ u: 16 / 64, v: 0 / 64, w: 8 / 64, h: 8 / 64 });
   });
 
   it('computes body face UVs (8x12x4 at origin 16,16)', () => {
     const uvs = computeFaceUVs(16, 16, 8, 12, 4, TEX_W, TEX_H);
-    expect(uvs.top).toEqual({ u: 20/64, v: 16/64, w: 8/64, h: 4/64 });
-    expect(uvs.front).toEqual({ u: 20/64, v: 20/64, w: 8/64, h: 12/64 });
+    expect(uvs.top).toEqual({ u: 20 / 64, v: 16 / 64, w: 8 / 64, h: 4 / 64 });
+    expect(uvs.front).toEqual({ u: 20 / 64, v: 20 / 64, w: 8 / 64, h: 12 / 64 });
   });
 
   it('computes right arm face UVs (4x12x4 at origin 40,16)', () => {
     const uvs = computeFaceUVs(40, 16, 4, 12, 4, TEX_W, TEX_H);
-    expect(uvs.front).toEqual({ u: 44/64, v: 20/64, w: 4/64, h: 12/64 });
+    expect(uvs.front).toEqual({ u: 44 / 64, v: 20 / 64, w: 4 / 64, h: 12 / 64 });
   });
 });

--- a/src/model/SkinParser.ts
+++ b/src/model/SkinParser.ts
@@ -1,9 +1,9 @@
 /** 1面分のUV座標（0.0〜1.0正規化済み） */
 export interface FaceUV {
-  u: number;  // 左上U
-  v: number;  // 左上V
-  w: number;  // 幅
-  h: number;  // 高さ
+  u: number; // 左上U
+  v: number; // 左上V
+  w: number; // 幅
+  h: number; // 高さ
 }
 
 /** パーツの6面分のUV */
@@ -32,9 +32,13 @@ export interface FaceUVs {
  * @param texH テクスチャ全体の高さ（ピクセル）
  */
 export function computeFaceUVs(
-  originX: number, originY: number,
-  w: number, h: number, d: number,
-  texW: number, texH: number,
+  originX: number,
+  originY: number,
+  w: number,
+  h: number,
+  d: number,
+  texW: number,
+  texH: number,
 ): FaceUVs {
   const norm = (px: number, py: number, pw: number, ph: number): FaceUV => ({
     u: (originX + px) / texW,
@@ -44,11 +48,11 @@ export function computeFaceUVs(
   });
 
   return {
-    top:    norm(d, 0, w, d),
+    top: norm(d, 0, w, d),
     bottom: norm(d + w, 0, w, d),
-    left:   norm(0, d, d, h),
-    front:  norm(d, d, w, h),
-    right:  norm(d + w, d, d, h),
-    back:   norm(d + w + d, d, w, h),
+    left: norm(0, d, d, h),
+    front: norm(d, d, w, h),
+    right: norm(d + w, d, d, h),
+    back: norm(d + w + d, d, w, h),
   };
 }

--- a/src/physics/EntityPhysics.test.ts
+++ b/src/physics/EntityPhysics.test.ts
@@ -12,12 +12,10 @@ import {
 import { KnockbackState } from './Knockback';
 
 // テスト用 WorldLike: すべて空気
-const emptyWorld = { getBlock: (_x: number, _y: number, _z: number) => 0 };
+const emptyWorld = { getBlock: () => 0 };
 
 // 指定座標のブロックのみ固体なWorldLikeを生成
-function worldWithBlocks(
-  blocks: Array<{ x: number; y: number; z: number }>,
-) {
+function worldWithBlocks(blocks: Array<{ x: number; y: number; z: number }>) {
   return {
     getBlock(bx: number, by: number, bz: number): number {
       for (const b of blocks) {

--- a/src/physics/EntityPhysics.ts
+++ b/src/physics/EntityPhysics.ts
@@ -8,8 +8,8 @@ export interface EntityBody {
   x: number;
   y: number;
   z: number;
-  width: number;   // XZ断面は正方形 (width x width)
-  height: number;  // Y軸の高さ
+  width: number; // XZ断面は正方形 (width x width)
+  height: number; // Y軸の高さ
   velocityY: number;
   onGround: boolean;
 }

--- a/src/physics/Knockback.test.ts
+++ b/src/physics/Knockback.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { KnockbackState, applyKnockback, updateKnockback, createKnockbackState,
-  KNOCKBACK_HORIZONTAL, KNOCKBACK_VERTICAL } from './Knockback';
+import {
+  KnockbackState,
+  applyKnockback,
+  updateKnockback,
+  createKnockbackState,
+  KNOCKBACK_HORIZONTAL,
+  KNOCKBACK_VERTICAL,
+} from './Knockback';
 
 describe('KnockbackState', () => {
   it('only has vx and vz fields', () => {

--- a/src/physics/Knockback.ts
+++ b/src/physics/Knockback.ts
@@ -9,8 +9,12 @@ export interface KnockbackState {
 
 export function applyKnockback(
   state: KnockbackState,
-  sourceX: number, sourceY: number, sourceZ: number,
-  targetX: number, targetY: number, targetZ: number,
+  sourceX: number,
+  sourceY: number,
+  sourceZ: number,
+  targetX: number,
+  targetY: number,
+  targetZ: number,
 ): void {
   let dx = targetX - sourceX;
   let dz = targetZ - sourceZ;

--- a/src/physics/Pathfinding.ts
+++ b/src/physics/Pathfinding.ts
@@ -10,7 +10,7 @@ export const LANE_Z_MIN = 2;
 export const LANE_Z_MAX = 207;
 
 /** グリッドセルサイズ（1ブロック=1セル） */
-const CELL_SIZE = 1;
+// Grid resolution: 1 block = 1 cell
 
 interface Node {
   x: number;
@@ -49,8 +49,10 @@ export function buildObstacleMap(structures: Structure[]): Set<string> {
  * @returns ウェイポイント配列（start除外、goal含む）。到達不可能な場合は空配列。
  */
 export function findPath(
-  startX: number, startZ: number,
-  goalX: number, goalZ: number,
+  startX: number,
+  startZ: number,
+  goalX: number,
+  goalZ: number,
   blocked: Set<string>,
 ): { x: number; z: number }[] {
   const sx = Math.round(startX);
@@ -85,7 +87,8 @@ export function findPath(
   const closed = new Set<string>();
 
   const startNode: Node = {
-    x: sx, z: sz,
+    x: sx,
+    z: sz,
     g: 0,
     h: heuristic(sx, sz, finalGX, finalGZ),
     f: 0,
@@ -96,13 +99,16 @@ export function findPath(
 
   // 8方向移動（直線+斜め）
   const dirs = [
-    [0, 1], [0, -1], [1, 0], [-1, 0],
-    [1, 1], [1, -1], [-1, 1], [-1, -1],
+    [0, 1],
+    [0, -1],
+    [1, 0],
+    [-1, 0],
+    [1, 1],
+    [1, -1],
+    [-1, 1],
+    [-1, -1],
   ];
-  const costs = [
-    1, 1, 1, 1,
-    1.414, 1.414, 1.414, 1.414,
-  ];
+  const costs = [1, 1, 1, 1, 1.414, 1.414, 1.414, 1.414];
 
   let iterations = 0;
   const MAX_ITERATIONS = 5000; // パフォーマンス制限（ARAMレーン210ブロック対応）
@@ -145,8 +151,11 @@ export function findPath(
       if (i >= 4) {
         const dx = dirs[i][0];
         const dz = dirs[i][1];
-        if (blocked.has(`${current.x + dx},${current.z}`) ||
-            blocked.has(`${current.x},${current.z + dz}`)) continue;
+        if (
+          blocked.has(`${current.x + dx},${current.z}`) ||
+          blocked.has(`${current.x},${current.z + dz}`)
+        )
+          continue;
       }
 
       const g = current.g + costs[i];

--- a/src/player/BlockInteraction.ts
+++ b/src/player/BlockInteraction.ts
@@ -15,8 +15,12 @@ export interface RaycastHit {
 
 export function castRay(
   world: World,
-  ox: number, oy: number, oz: number,
-  dx: number, dy: number, dz: number,
+  ox: number,
+  oy: number,
+  oz: number,
+  dx: number,
+  dy: number,
+  dz: number,
   maxDist: number,
 ): RaycastHit | null {
   let x = Math.floor(ox);
@@ -31,11 +35,13 @@ export function castRay(
   const tDeltaY = dy !== 0 ? Math.abs(1 / dy) : Infinity;
   const tDeltaZ = dz !== 0 ? Math.abs(1 / dz) : Infinity;
 
-  let tMaxX = dx !== 0 ? ((dx > 0 ? x + 1 - ox : ox - x) / Math.abs(dx)) : Infinity;
-  let tMaxY = dy !== 0 ? ((dy > 0 ? y + 1 - oy : oy - y) / Math.abs(dy)) : Infinity;
-  let tMaxZ = dz !== 0 ? ((dz > 0 ? z + 1 - oz : oz - z) / Math.abs(dz)) : Infinity;
+  let tMaxX = dx !== 0 ? (dx > 0 ? x + 1 - ox : ox - x) / Math.abs(dx) : Infinity;
+  let tMaxY = dy !== 0 ? (dy > 0 ? y + 1 - oy : oy - y) / Math.abs(dy) : Infinity;
+  let tMaxZ = dz !== 0 ? (dz > 0 ? z + 1 - oz : oz - z) / Math.abs(dz) : Infinity;
 
-  let normalX = 0, normalY = 0, normalZ = 0;
+  let normalX = 0,
+    normalY = 0,
+    normalZ = 0;
   let t = 0;
 
   for (let i = 0; i < maxDist * 3; i++) {
@@ -49,13 +55,17 @@ export function castRay(
         if (t > maxDist) return null;
         x += stepX;
         tMaxX += tDeltaX;
-        normalX = -stepX; normalY = 0; normalZ = 0;
+        normalX = -stepX;
+        normalY = 0;
+        normalZ = 0;
       } else {
         t = tMaxZ;
         if (t > maxDist) return null;
         z += stepZ;
         tMaxZ += tDeltaZ;
-        normalX = 0; normalY = 0; normalZ = -stepZ;
+        normalX = 0;
+        normalY = 0;
+        normalZ = -stepZ;
       }
     } else {
       if (tMaxY < tMaxZ) {
@@ -63,13 +73,17 @@ export function castRay(
         if (t > maxDist) return null;
         y += stepY;
         tMaxY += tDeltaY;
-        normalX = 0; normalY = -stepY; normalZ = 0;
+        normalX = 0;
+        normalY = -stepY;
+        normalZ = 0;
       } else {
         t = tMaxZ;
         if (t > maxDist) return null;
         z += stepZ;
         tMaxZ += tDeltaZ;
-        normalX = 0; normalY = 0; normalZ = -stepZ;
+        normalX = 0;
+        normalY = 0;
+        normalZ = -stepZ;
       }
     }
   }
@@ -79,7 +93,10 @@ export function castRay(
 export class BlockInteraction {
   private highlightMesh: THREE.LineSegments;
 
-  constructor(private world: World, scene: THREE.Scene) {
+  constructor(
+    private world: World,
+    scene: THREE.Scene,
+  ) {
     const geo = new THREE.BoxGeometry(1.001, 1.001, 1.001);
     const edges = new THREE.EdgesGeometry(geo);
     this.highlightMesh = new THREE.LineSegments(
@@ -91,8 +108,12 @@ export class BlockInteraction {
   }
 
   update(
-    eyeX: number, eyeY: number, eyeZ: number,
-    dirX: number, dirY: number, dirZ: number,
+    eyeX: number,
+    eyeY: number,
+    eyeZ: number,
+    dirX: number,
+    dirY: number,
+    dirZ: number,
   ): RaycastHit | null {
     const hit = castRay(this.world, eyeX, eyeY, eyeZ, dirX, dirY, dirZ, 5);
     if (hit && isDestructible(this.world.getBlock(hit.blockX, hit.blockY, hit.blockZ))) {
@@ -119,9 +140,12 @@ export class BlockInteraction {
     const HALF_W = PLAYER_WIDTH / 2;
     const P_HEIGHT = PLAYER_HEIGHT;
     if (
-      px + 1 > playerX - HALF_W && px < playerX + HALF_W &&
-      py + 1 > playerY && py < playerY + P_HEIGHT &&
-      pz + 1 > playerZ - HALF_W && pz < playerZ + HALF_W
+      px + 1 > playerX - HALF_W &&
+      px < playerX + HALF_W &&
+      py + 1 > playerY &&
+      py < playerY + P_HEIGHT &&
+      pz + 1 > playerZ - HALF_W &&
+      pz < playerZ + HALF_W
     ) {
       return false;
     }

--- a/src/player/Camera.ts
+++ b/src/player/Camera.ts
@@ -17,9 +17,7 @@ export class FPSCamera {
     this.yaw -= deltaX * SENSITIVITY;
     this.pitch -= deltaY * SENSITIVITY;
     this.pitch = Math.max(-PITCH_LIMIT, Math.min(PITCH_LIMIT, this.pitch));
-    this.camera.quaternion.setFromEuler(
-      new THREE.Euler(this.pitch, this.yaw, 0, 'YXZ'),
-    );
+    this.camera.quaternion.setFromEuler(new THREE.Euler(this.pitch, this.yaw, 0, 'YXZ'));
   }
 
   setPosition(x: number, y: number, z: number): void {

--- a/src/player/Player.ts
+++ b/src/player/Player.ts
@@ -25,7 +25,12 @@ export class Player implements EntityBody {
   onGround = false;
   knockback: KnockbackState = createKnockbackState();
 
-  constructor(x: number, y: number, z: number, private world: World) {
+  constructor(
+    x: number,
+    y: number,
+    z: number,
+    private world: World,
+  ) {
     this.x = x;
     this.y = y;
     this.z = z;
@@ -47,7 +52,13 @@ export class Player implements EntityBody {
     tryJump(this);
   }
 
-  get eyeX(): number { return this.x; }
-  get eyeY(): number { return this.y + PLAYER_EYE_HEIGHT; }
-  get eyeZ(): number { return this.z; }
+  get eyeX(): number {
+    return this.x;
+  }
+  get eyeY(): number {
+    return this.y + PLAYER_EYE_HEIGHT;
+  }
+  get eyeZ(): number {
+    return this.z;
+  }
 }

--- a/src/player/PlayerState.test.ts
+++ b/src/player/PlayerState.test.ts
@@ -103,7 +103,9 @@ describe('PlayerState', () => {
     it('onDeath callback is called on death', () => {
       const ps = new PlayerState();
       let called = false;
-      ps.onDeath(() => { called = true; });
+      ps.onDeath(() => {
+        called = true;
+      });
       ps.takeDamage(500);
       expect(called).toBe(true);
     });
@@ -111,7 +113,9 @@ describe('PlayerState', () => {
     it('onDeath callback is not called on non-lethal damage', () => {
       const ps = new PlayerState();
       let called = false;
-      ps.onDeath(() => { called = true; });
+      ps.onDeath(() => {
+        called = true;
+      });
       ps.takeDamage(50);
       expect(called).toBe(false);
     });

--- a/src/player/ViewMode.ts
+++ b/src/player/ViewMode.ts
@@ -6,12 +6,22 @@ const MODE_CYCLE: ViewModeType[] = ['first-person', 'third-person-back'];
 export class ViewMode {
   private modeIndex = 0;
 
-  get current(): ViewModeType { return MODE_CYCLE[this.modeIndex]; }
-  get isFirstPerson(): boolean { return this.current === 'first-person'; }
+  get current(): ViewModeType {
+    return MODE_CYCLE[this.modeIndex];
+  }
+  get isFirstPerson(): boolean {
+    return this.current === 'first-person';
+  }
 
-  toggle(): void { this.modeIndex = (this.modeIndex + 1) % MODE_CYCLE.length; }
+  toggle(): void {
+    this.modeIndex = (this.modeIndex + 1) % MODE_CYCLE.length;
+  }
 
-  getCameraOffset(forwardX: number, forwardY: number, forwardZ: number): { x: number; y: number; z: number } {
+  getCameraOffset(
+    forwardX: number,
+    forwardY: number,
+    forwardZ: number,
+  ): { x: number; y: number; z: number } {
     if (this.current === 'first-person') return { x: 0, y: 0, z: 0 };
     return {
       x: -forwardX * THIRD_PERSON_DISTANCE,

--- a/src/ui/HUD.test.ts
+++ b/src/ui/HUD.test.ts
@@ -56,11 +56,33 @@ function setupDOM(): void {
   damageFlash.id = 'damage-flash';
   damageFlash.style.display = 'none';
 
-  document.body.append(targetInfo, feedback, victory, playerHpBarFill, playerHpText, deathOverlay, towerWarning, damageFlash);
+  document.body.append(
+    targetInfo,
+    feedback,
+    victory,
+    playerHpBarFill,
+    playerHpText,
+    deathOverlay,
+    towerWarning,
+    damageFlash,
+  );
 }
 
 function createStructure(hp: number, maxHp: number): Structure {
-  const s = new Structure('red-t2', 'red', 8, 4, 168, 'tower', maxHp, 3, 6, 3, BlockType.RED_TOWER, null);
+  const s = new Structure(
+    'red-t2',
+    'red',
+    8,
+    4,
+    168,
+    'tower',
+    maxHp,
+    3,
+    6,
+    3,
+    BlockType.RED_TOWER,
+    null,
+  );
   if (hp < maxHp) s.takeDamage(maxHp - hp);
   return s;
 }

--- a/src/ui/HealthBar3D.test.ts
+++ b/src/ui/HealthBar3D.test.ts
@@ -24,7 +24,7 @@ describe('HealthBar3D', () => {
   it('is invisible when dead (hp=0)', () => {
     const sprite = createHealthBar(1.5);
     updateHealthBar(sprite, 100, 150); // まず表示させる
-    updateHealthBar(sprite, 0, 150);   // 死亡で非表示
+    updateHealthBar(sprite, 0, 150); // 死亡で非表示
     expect(sprite.visible).toBe(false);
   });
 

--- a/src/ui/HealthBar3D.ts
+++ b/src/ui/HealthBar3D.ts
@@ -15,9 +15,17 @@ function createBarTexture(): THREE.DataTexture {
   return texture;
 }
 
-function writePixel(data: Uint8Array, x: number, y: number, r: number, g: number, b: number, a = 255): void {
+function writePixel(
+  data: Uint8Array,
+  x: number,
+  y: number,
+  r: number,
+  g: number,
+  b: number,
+  a = 255,
+): void {
   const idx = (y * BAR_WIDTH + x) * 4;
-  data[idx]     = r;
+  data[idx] = r;
   data[idx + 1] = g;
   data[idx + 2] = b;
   data[idx + 3] = a;
@@ -30,11 +38,17 @@ function redrawBar(texture: THREE.DataTexture, ratio: number): void {
   // 色の決定: 緑 → 黄 → 赤
   let fr: number, fg: number, fb: number;
   if (ratio > 0.5) {
-    fr = 0x44; fg = 0xbb; fb = 0x44;   // 緑
+    fr = 0x44;
+    fg = 0xbb;
+    fb = 0x44; // 緑
   } else if (ratio > 0.25) {
-    fr = 0xdd; fg = 0xbb; fb = 0x22;   // 黄
+    fr = 0xdd;
+    fg = 0xbb;
+    fb = 0x22; // 黄
   } else {
-    fr = 0xdd; fg = 0x33; fb = 0x33;   // 赤
+    fr = 0xdd;
+    fg = 0x33;
+    fb = 0x33; // 赤
   }
 
   for (let y = 0; y < BAR_HEIGHT; y++) {

--- a/src/world/Block.test.ts
+++ b/src/world/Block.test.ts
@@ -58,7 +58,12 @@ describe('Block', () => {
   });
 
   it('structure blocks have same texture for all faces', () => {
-    for (const bt of [BlockType.BLUE_TOWER, BlockType.RED_TOWER, BlockType.BLUE_NEXUS, BlockType.RED_NEXUS]) {
+    for (const bt of [
+      BlockType.BLUE_TOWER,
+      BlockType.RED_TOWER,
+      BlockType.BLUE_NEXUS,
+      BlockType.RED_NEXUS,
+    ]) {
       const uvs = getBlockUVs(bt);
       expect(uvs.top).toBe(uvs.side);
       expect(uvs.top).toBe(uvs.bottom);

--- a/src/world/Block.ts
+++ b/src/world/Block.ts
@@ -15,12 +15,14 @@ export function isSolid(type: BlockType): boolean {
 }
 
 export function isDestructible(type: BlockType): boolean {
-  return type !== BlockType.AIR
-    && type !== BlockType.BEDROCK
-    && type !== BlockType.BLUE_TOWER
-    && type !== BlockType.RED_TOWER
-    && type !== BlockType.BLUE_NEXUS
-    && type !== BlockType.RED_NEXUS;
+  return (
+    type !== BlockType.AIR &&
+    type !== BlockType.BEDROCK &&
+    type !== BlockType.BLUE_TOWER &&
+    type !== BlockType.RED_TOWER &&
+    type !== BlockType.BLUE_NEXUS &&
+    type !== BlockType.RED_NEXUS
+  );
 }
 
 interface BlockUVs {

--- a/src/world/Chunk.ts
+++ b/src/world/Chunk.ts
@@ -28,9 +28,7 @@ export class Chunk {
   }
 
   private inBounds(x: number, y: number, z: number): boolean {
-    return x >= 0 && x < CHUNK_SIZE &&
-           y >= 0 && y < CHUNK_SIZE &&
-           z >= 0 && z < CHUNK_SIZE;
+    return x >= 0 && x < CHUNK_SIZE && y >= 0 && y < CHUNK_SIZE && z >= 0 && z < CHUNK_SIZE;
   }
 
   getBlock(x: number, y: number, z: number): BlockType {

--- a/src/world/ChunkMesher.ts
+++ b/src/world/ChunkMesher.ts
@@ -11,16 +11,78 @@ export interface ChunkGeometryData {
 type GetBlockFn = (wx: number, wy: number, wz: number) => BlockType;
 
 const FACES = [
-  { dir: [1, 0, 0], corners: [[1,0,0],[1,1,0],[1,1,1],[1,0,1]], normal: [1,0,0], uvFace: 'side' as const },
-  { dir: [-1, 0, 0], corners: [[0,0,1],[0,1,1],[0,1,0],[0,0,0]], normal: [-1,0,0], uvFace: 'side' as const },
-  { dir: [0, 1, 0], corners: [[0,1,0],[0,1,1],[1,1,1],[1,1,0]], normal: [0,1,0], uvFace: 'top' as const },
-  { dir: [0, -1, 0], corners: [[0,0,1],[0,0,0],[1,0,0],[1,0,1]], normal: [0,-1,0], uvFace: 'bottom' as const },
-  { dir: [0, 0, 1], corners: [[0,0,1],[1,0,1],[1,1,1],[0,1,1]], normal: [0,0,1], uvFace: 'side' as const },
-  { dir: [0, 0, -1], corners: [[1,0,0],[0,0,0],[0,1,0],[1,1,0]], normal: [0,0,-1], uvFace: 'side' as const },
+  {
+    dir: [1, 0, 0],
+    corners: [
+      [1, 0, 0],
+      [1, 1, 0],
+      [1, 1, 1],
+      [1, 0, 1],
+    ],
+    normal: [1, 0, 0],
+    uvFace: 'side' as const,
+  },
+  {
+    dir: [-1, 0, 0],
+    corners: [
+      [0, 0, 1],
+      [0, 1, 1],
+      [0, 1, 0],
+      [0, 0, 0],
+    ],
+    normal: [-1, 0, 0],
+    uvFace: 'side' as const,
+  },
+  {
+    dir: [0, 1, 0],
+    corners: [
+      [0, 1, 0],
+      [0, 1, 1],
+      [1, 1, 1],
+      [1, 1, 0],
+    ],
+    normal: [0, 1, 0],
+    uvFace: 'top' as const,
+  },
+  {
+    dir: [0, -1, 0],
+    corners: [
+      [0, 0, 1],
+      [0, 0, 0],
+      [1, 0, 0],
+      [1, 0, 1],
+    ],
+    normal: [0, -1, 0],
+    uvFace: 'bottom' as const,
+  },
+  {
+    dir: [0, 0, 1],
+    corners: [
+      [0, 0, 1],
+      [1, 0, 1],
+      [1, 1, 1],
+      [0, 1, 1],
+    ],
+    normal: [0, 0, 1],
+    uvFace: 'side' as const,
+  },
+  {
+    dir: [0, 0, -1],
+    corners: [
+      [1, 0, 0],
+      [0, 0, 0],
+      [0, 1, 0],
+      [1, 1, 0],
+    ],
+    normal: [0, 0, -1],
+    uvFace: 'side' as const,
+  },
 ];
 
 export function buildChunkGeometryData(
-  chunkX: number, chunkY: number, chunkZ: number,
+  chunkX: number,
+  chunkY: number,
+  chunkZ: number,
   getBlock: GetBlockFn,
 ): ChunkGeometryData {
   const positions: number[] = [];
@@ -67,8 +129,12 @@ export function buildChunkGeometryData(
           uvs.push(u0, v0, u0, v1, u1, v1, u1, v0);
 
           indices.push(
-            vertexStart, vertexStart + 1, vertexStart + 2,
-            vertexStart, vertexStart + 2, vertexStart + 3,
+            vertexStart,
+            vertexStart + 1,
+            vertexStart + 2,
+            vertexStart,
+            vertexStart + 2,
+            vertexStart + 3,
           );
         }
       }

--- a/src/world/MapData.test.ts
+++ b/src/world/MapData.test.ts
@@ -47,11 +47,13 @@ describe('MapData', () => {
 
   it('spawn position is above ground in air', () => {
     expect(SPAWN_POSITION.y).toBeGreaterThan(3);
-    expect(world.getBlock(
-      Math.floor(SPAWN_POSITION.x),
-      Math.floor(SPAWN_POSITION.y),
-      Math.floor(SPAWN_POSITION.z),
-    )).toBe(BlockType.AIR);
+    expect(
+      world.getBlock(
+        Math.floor(SPAWN_POSITION.x),
+        Math.floor(SPAWN_POSITION.y),
+        Math.floor(SPAWN_POSITION.z),
+      ),
+    ).toBe(BlockType.AIR);
   });
 
   it('generates 6 structures', () => {
@@ -59,7 +61,7 @@ describe('MapData', () => {
   });
 
   it('structures are symmetrically placed', () => {
-    const byId = new Map(structures.map(s => [s.id, s]));
+    const byId = new Map(structures.map((s) => [s.id, s]));
 
     const blueNexus = byId.get('blue-nexus')!;
     const redNexus = byId.get('red-nexus')!;
@@ -71,27 +73,27 @@ describe('MapData', () => {
   });
 
   it('red tower blocks are RED_TOWER', () => {
-    const redT1 = structures.find(s => s.id === 'red-t1')!;
+    const redT1 = structures.find((s) => s.id === 'red-t1')!;
     expect(world.getBlock(redT1.x, redT1.y, redT1.z)).toBe(BlockType.RED_TOWER);
   });
 
   it('blue tower blocks are BLUE_TOWER', () => {
-    const blueT1 = structures.find(s => s.id === 'blue-t1')!;
+    const blueT1 = structures.find((s) => s.id === 'blue-t1')!;
     expect(world.getBlock(blueT1.x, blueT1.y, blueT1.z)).toBe(BlockType.BLUE_TOWER);
   });
 
   it('red nexus blocks are RED_NEXUS', () => {
-    const redNexus = structures.find(s => s.id === 'red-nexus')!;
+    const redNexus = structures.find((s) => s.id === 'red-nexus')!;
     expect(world.getBlock(redNexus.x, redNexus.y, redNexus.z)).toBe(BlockType.RED_NEXUS);
   });
 
   it('blue nexus blocks are BLUE_NEXUS', () => {
-    const blueNexus = structures.find(s => s.id === 'blue-nexus')!;
+    const blueNexus = structures.find((s) => s.id === 'blue-nexus')!;
     expect(world.getBlock(blueNexus.x, blueNexus.y, blueNexus.z)).toBe(BlockType.BLUE_NEXUS);
   });
 
   it('protection chain: T1(outer) -> T2(inner) -> Nexus', () => {
-    const byId = new Map(structures.map(s => [s.id, s]));
+    const byId = new Map(structures.map((s) => [s.id, s]));
     const redT1 = byId.get('red-t1')!;
     const redT2 = byId.get('red-t2')!;
     const redNexus = byId.get('red-nexus')!;

--- a/src/world/MapData.ts
+++ b/src/world/MapData.ts
@@ -3,14 +3,11 @@ import { BlockType } from './Block';
 import { Structure } from '../entity/Structure';
 
 const MAP_WIDTH = 19;
-const MAP_HEIGHT = 10;
 const MAP_LENGTH = 210;
 
 const LANE_X_START = 2;
 const LANE_X_END = 16;
 const LANE_Z_START = 2;
-const LANE_Z_END = 207;
-
 const BEDROCK_Y = 0;
 const DIRT_Y_START = 1;
 const DIRT_Y_END = 2;
@@ -79,15 +76,93 @@ function createStructures(world: World): Structure[] {
 
   // Blue side: T1(outer, z=71) → T2(inner, z=38) → Nexus(z=6)
   // Red approaching from high-z attacks: T1 first, then T2, then Nexus
-  const blueT1 = new Structure('blue-t1', 'blue', 8, STRUCTURE_Y, 71, 'tower', TOWER_HP, 3, 6, 3, BlockType.BLUE_TOWER, null);
-  const blueT2 = new Structure('blue-t2', 'blue', 8, STRUCTURE_Y, 38, 'tower', TOWER_HP, 3, 6, 3, BlockType.BLUE_TOWER, blueT1);
-  const blueNexus = new Structure('blue-nexus', 'blue', 7, STRUCTURE_Y, 6, 'nexus', NEXUS_HP, 5, 4, 5, BlockType.BLUE_NEXUS, blueT2);
+  const blueT1 = new Structure(
+    'blue-t1',
+    'blue',
+    8,
+    STRUCTURE_Y,
+    71,
+    'tower',
+    TOWER_HP,
+    3,
+    6,
+    3,
+    BlockType.BLUE_TOWER,
+    null,
+  );
+  const blueT2 = new Structure(
+    'blue-t2',
+    'blue',
+    8,
+    STRUCTURE_Y,
+    38,
+    'tower',
+    TOWER_HP,
+    3,
+    6,
+    3,
+    BlockType.BLUE_TOWER,
+    blueT1,
+  );
+  const blueNexus = new Structure(
+    'blue-nexus',
+    'blue',
+    7,
+    STRUCTURE_Y,
+    6,
+    'nexus',
+    NEXUS_HP,
+    5,
+    4,
+    5,
+    BlockType.BLUE_NEXUS,
+    blueT2,
+  );
 
   // Red side: T1(outer, z=136) → T2(inner, z=168) → Nexus(z=198)
   // Blue player approaching from low-z attacks: T1 first, then T2, then Nexus
-  const redT1 = new Structure('red-t1', 'red', 8, STRUCTURE_Y, 136, 'tower', TOWER_HP, 3, 6, 3, BlockType.RED_TOWER, null);
-  const redT2 = new Structure('red-t2', 'red', 8, STRUCTURE_Y, 168, 'tower', TOWER_HP, 3, 6, 3, BlockType.RED_TOWER, redT1);
-  const redNexus = new Structure('red-nexus', 'red', 7, STRUCTURE_Y, 198, 'nexus', NEXUS_HP, 5, 4, 5, BlockType.RED_NEXUS, redT2);
+  const redT1 = new Structure(
+    'red-t1',
+    'red',
+    8,
+    STRUCTURE_Y,
+    136,
+    'tower',
+    TOWER_HP,
+    3,
+    6,
+    3,
+    BlockType.RED_TOWER,
+    null,
+  );
+  const redT2 = new Structure(
+    'red-t2',
+    'red',
+    8,
+    STRUCTURE_Y,
+    168,
+    'tower',
+    TOWER_HP,
+    3,
+    6,
+    3,
+    BlockType.RED_TOWER,
+    redT1,
+  );
+  const redNexus = new Structure(
+    'red-nexus',
+    'red',
+    7,
+    STRUCTURE_Y,
+    198,
+    'nexus',
+    NEXUS_HP,
+    5,
+    4,
+    5,
+    BlockType.RED_NEXUS,
+    redT2,
+  );
 
   const all = [blueNexus, blueT1, blueT2, redT2, redT1, redNexus];
   for (const s of all) {

--- a/src/world/World.ts
+++ b/src/world/World.ts
@@ -36,11 +36,7 @@ export class World {
     const cz = this.toChunkCoord(wz);
     const chunk = this.getChunk(cx, cy, cz);
     if (!chunk) return BlockType.AIR;
-    return chunk.getBlock(
-      this.toLocalCoord(wx),
-      this.toLocalCoord(wy),
-      this.toLocalCoord(wz),
-    );
+    return chunk.getBlock(this.toLocalCoord(wx), this.toLocalCoord(wy), this.toLocalCoord(wz));
   }
 
   setBlock(wx: number, wy: number, wz: number, type: BlockType): void {


### PR DESCRIPTION
## Summary
- ESLint v9 (flat config) + typescript-eslint + eslint-config-prettier 導入
- Prettier（既存コードスタイルに合わせた設定: singleQuote, trailingComma: all, printWidth: 100）
- 全64ファイルのlint/format修正（未使用import削除、`any` → `unknown`、フォーマット統一）
- CIに `lint` + `format:check` ステップ追加

Closes #10

## Test plan
- [x] `npx eslint src/` — エラー0
- [x] `npx prettier --check src/` — 差分なし
- [x] `npx vitest run` — 582テスト全通過
- [x] `npm run build` — ビルド成功
- [ ] CIで lint → format → typecheck → test → build 全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)